### PR TITLE
Keep track of collected Fees

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -180,6 +180,7 @@ contract BridgeImpl is
         uint256 actualWithdrawalAmount = msg.value - config.fee;
         if (actualWithdrawalAmount < config.minAmount) revert InvalidAmount();
         if (actualWithdrawalAmount > config.maxAmount) revert InvalidAmount();
+        _addUnclaimedRewards(config.fee);
 
         uint256 amountForHashing = GasBridgeLib._removeTenDecimals(
             actualWithdrawalAmount
@@ -458,6 +459,7 @@ contract BridgeImpl is
         if (tokenValue > config.maxAmount) revert InvalidAmount();
         if (msg.value < config.fee)
             revert InsufficientFee(msg.value, config.fee);
+        _addUnclaimedRewards(msg.value);
 
         // Execute the transfer of the tokens from the sender to the bridge contract.
         bool success = IERC20(_neoXToken).transferFrom(

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -22,6 +22,8 @@ contract BridgeStorage is UUPSUpgradeable {
     StorageTypes.GasBridge public gasBridge;
     mapping(uint256 nonce => StorageTypes.Claimable claimable)
         public claimableGas;
+    // Unclaimed Fee Rewards
+    uint256 public unclaimedRewards;
     // Token Bridges
     mapping(address tokenAddress => StorageTypes.TokenBridge tokenBridge)
         public tokenBridges;
@@ -127,6 +129,8 @@ contract BridgeStorage is UUPSUpgradeable {
         _;
     }
 
+    // Pause Bridge functions
+
     function _pauseBridge() internal {
         bridgePaused = true;
     }
@@ -134,6 +138,14 @@ contract BridgeStorage is UUPSUpgradeable {
     function _unpauseBridge() internal {
         bridgePaused = false;
     }
+
+    // Unclaimed Rewards functions
+
+    function _addUnclaimedRewards(uint256 _amount) internal {
+        unclaimedRewards += _amount;
+    }
+
+    // Gas Bridge functions
 
     function _pauseGasBridge() internal {
         gasBridge.config.paused = true;

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -80,7 +80,7 @@ describe("Bridge Implementation", function () {
             const newFee = ethers.parseEther("0.2");
             const tx = await bridgeContract.connect(governor).setGasWithdrawalFee(newFee);
             await expect(tx).to.emit(bridgeContract, "GasWithdrawalFeeChange").withArgs(newFee);
-            gasBridge = await bridgeContract.gasBridge()
+            gasBridge = await bridgeContract.gasBridge();
             expect(gasBridge.config.fee).to.be.equal(newFee);
         });
 
@@ -611,6 +611,30 @@ describe("Bridge Implementation", function () {
             const tooHighWithdrawalAmount = maxWithdrawalAmount + withdrawlFee + minFraction;
             await expect(bridgeContract.connect(validator7).withdrawGas(validator6, { value: tooHighWithdrawalAmount })).to.be.revertedWithCustomError(bridgeContract, "InvalidAmount");
             validator7.sendTransaction({ to: validator6, value: ethers.parseEther("1000") });
+        });
+
+        it("Withdraw with different fees and verify unclaimed rewards", async function () {
+            const { bridgeContract, relayer, funder, governor } = await loadFixture(deployBridgeFixture);
+
+            let withdrawalAmount_1 = ethers.parseEther("10");
+            let withdrawalAmount_2 = ethers.parseEther("20");
+            let withdrawalFeeBeforeChange = (await bridgeContract.gasBridge()).config.fee;
+            expect(withdrawalFeeBeforeChange).to.be.equal(ethers.parseEther("0.1"));
+            expect(await bridgeContract.unclaimedRewards()).to.be.equal(0);
+
+            const to1 = relayer.address;
+            await bridgeContract.connect(relayer).withdrawGas(to1, { value: withdrawalAmount_1 });
+
+            await bridgeContract.connect(governor).setGasWithdrawalFee(ethers.parseEther("0.5"));
+            const withdrawalFeeAfterChange = (await bridgeContract.gasBridge()).config.fee;
+            expect(withdrawalFeeAfterChange).to.be.equal(ethers.parseEther("0.5"));
+
+            const to2 = funder.address;
+            const tx2 = await bridgeContract.connect(relayer).withdrawGas(to2, { value: withdrawalAmount_2 });
+
+            let withdrawalState = (await bridgeContract.gasBridge()).withdrawalState;
+            expect(withdrawalState.nonce).to.be.equal(2);
+            expect(await bridgeContract.unclaimedRewards()).to.be.equal(withdrawalFeeBeforeChange + withdrawalFeeAfterChange);
         });
     });
 


### PR DESCRIPTION
Resolves #90 

There's currently no mechanism for claiming the fees since we haven't decided on it. This change just allows us to easily keep track of how much fees have been paid overall.