### PR TITLE
Update TokenBridgeLib.sol

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -415,7 +415,8 @@ contract BridgeImpl is
                 tokenType == StorageTypes.TokenType.ERC20Capped
         );
         // Note: For NEO tokens, the transfer value has already been extended with 18 decimals in the deposit function.
-        TokenBridgeLib._executeERC20Transfer(_neoXToken, claimable.amount, to);
+        bool success = TokenBridgeLib._executeERC20Transfer(_neoXToken, claimable.amount, to);
+        if(!success) revert TransferFailed();
     }
 
     function _emitTransferEventOrAddNewTokenClaimable(

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -416,7 +416,7 @@ contract BridgeImpl is
         );
         // Note: For NEO tokens, the transfer value has already been extended with 18 decimals in the deposit function.
         bool success = TokenBridgeLib._executeERC20Transfer(_neoXToken, claimable.amount, to);
-        if(!success) revert TransferFailed();
+        if (!success) revert TransferFailed();
     }
 
     function _emitTransferEventOrAddNewTokenClaimable(

--- a/contracts/library/TokenBridgeLib.sol
+++ b/contracts/library/TokenBridgeLib.sol
@@ -19,7 +19,7 @@ library TokenBridgeLib {
     ) internal returns (bool) {
         bytes memory transferCall = abi.encodeCall(IERC20.transfer, (_to, _amount));
         (bool success, bytes memory returndata) = address(_neoXToken).call(transferCall);
-        return success && (returndata.length == 0 || abi.decode(returndata, (bool))) && address(_neoXToken).code.length > 0;
+        return success && (returndata.length == 0 || abi.decode(returndata, (bool)));
     }
 
     /**

--- a/contracts/library/TokenBridgeLib.sol
+++ b/contracts/library/TokenBridgeLib.sol
@@ -17,7 +17,9 @@ library TokenBridgeLib {
         uint256 _amount,
         address _to
     ) internal returns (bool) {
-        return IERC20(_neoXToken).transfer(_to, _amount);
+        bytes memory transferCall = abi.encodeCall(IERC20.transfer, (_to, _amount));
+        (bool success, bytes memory returndata) = address(_neoXToken).call(transferCall);
+        return success && (returndata.length == 0 || abi.decode(returndata, (bool))) && address(_neoXToken).code.length > 0;
     }
 
     /**


### PR DESCRIPTION
Use safeTransfer to prevent from directly throwing an error when the transfer transaction fails.
For example, [default ERC20 token contract](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol#L104) will revert error instead of return a `false` if the transfer failed.