### PR TITLE
Fix event in `unpauseTokenBridge` and rename Token Bridge Pause Events

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -264,7 +264,7 @@ contract BridgeImpl is
         address _neoXToken
     ) external override onlyTokenBridgeUnpaused(_neoXToken) onlySecurityGuard {
         _pauseToken(_neoXToken);
-        emit TokenPause(_neoXToken, _getNeoN3Token(_neoXToken));
+        emit TokenBridgePause(_neoXToken, _getNeoN3Token(_neoXToken));
     }
 
     /**
@@ -275,7 +275,7 @@ contract BridgeImpl is
         address _neoXToken
     ) external override onlyTokenBridgePaused(_neoXToken) onlyGovernor {
         _unpauseToken(_neoXToken);
-        emit TokenPause(_neoXToken, _getNeoN3Token(_neoXToken));
+        emit TokenBridgeUnpause(_neoXToken, _getNeoN3Token(_neoXToken));
     }
 
     /**
@@ -418,7 +418,11 @@ contract BridgeImpl is
                 executionType == StorageTypes.ExecutionType.ERC20
         );
         // Note: For NEO tokens, the transfer value has already been extended with 18 decimals in the deposit function.
-        bool success = TokenBridgeLib._executeERC20Transfer(_neoXToken, claimable.amount, to);
+        bool success = TokenBridgeLib._executeERC20Transfer(
+            _neoXToken,
+            claimable.amount,
+            to
+        );
         if (!success) revert TransferFailed();
     }
 

--- a/contracts/interfaces/ITokenBridge.sol
+++ b/contracts/interfaces/ITokenBridge.sol
@@ -13,8 +13,14 @@ interface ITokenBridge {
         address indexed neoXToken,
         address indexed neoN3Token
     );
-    event TokenPause(address indexed neoXToken, address indexed neoN3Token);
-    event TokenUnpause(address indexed neoXToken, address indexed neoN3Token);
+    event TokenBridgePause(
+        address indexed neoXToken,
+        address indexed neoN3Token
+    );
+    event TokenBridgeUnpause(
+        address indexed neoXToken,
+        address indexed neoN3Token
+    );
     event TokenDeposit(
         address indexed neoXToken,
         uint256 indexed nonce,


### PR DESCRIPTION
Fixes #112.