### PR TITLE
Improve development structure for storage slot allocation in bridge

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -6,15 +6,8 @@ import "../interfaces/IBridge.sol";
 import "../interfaces/IGasBridge.sol";
 import "../interfaces/ITokenBridge.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract BridgeImpl is
-    BridgeStorage,
-    ReentrancyGuard,
-    IBridge,
-    IGasBridge,
-    ITokenBridge
-{
+contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     receive() external payable onlyFunder {
         emit Fund(msg.value);
     }

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -6,31 +6,14 @@ import "../library/BridgeLib.sol";
 import "../library/GasBridgeLib.sol";
 import "../library/StorageTypes.sol";
 import "../library/TokenBridgeLib.sol";
+import "./BridgeStorageV1.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-contract BridgeStorage is UUPSUpgradeable {
+contract BridgeStorage is UUPSUpgradeable, BridgeStorageV1, ReentrancyGuard {
     address public constant SELF = 0x1212100000000000000000000000000000000004;
     address public constant GOV_ADMIN =
         0x1212000000000000000000000000000000000000;
-
-    // Begin Storage Slots
-
-    // General Bridge Parameters
-    IBridgeManagement public management;
-    bool public bridgePaused;
-    // Gas Bridge
-    StorageTypes.GasBridge public gasBridge;
-    mapping(uint256 nonce => StorageTypes.Claimable claimable)
-        public claimableGas;
-    // Unclaimed Fee Rewards
-    uint256 public unclaimedRewards;
-    // Token Bridges
-    mapping(address tokenAddress => StorageTypes.TokenBridge tokenBridge)
-        public tokenBridges;
-    mapping(address tokenAddress => mapping(uint256 nonce => StorageTypes.Claimable claimable) claimableTokens)
-        public tokenClaimables;
-
-    // End Storage Slots
 
     constructor(address _management) {
         _disableInitializers();

--- a/contracts/bridge/BridgeStorageV1.sol
+++ b/contracts/bridge/BridgeStorageV1.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../interfaces/IBridgeManagement.sol";
+import "../library/StorageTypes.sol";
+
+contract BridgeStorageV1 {
+    IBridgeManagement public management;
+
+    bool public bridgePaused;
+
+    StorageTypes.GasBridge public gasBridge;
+    mapping(uint256 nonce => StorageTypes.Claimable claimable)
+        public claimableGas;
+
+    uint256 public unclaimedRewards;
+
+    mapping(address tokenAddress => StorageTypes.TokenBridge tokenBridge)
+        public tokenBridges;
+    mapping(address tokenAddress => mapping(uint256 nonce => StorageTypes.Claimable claimable) claimableTokens)
+        public tokenClaimables;
+}


### PR DESCRIPTION
Technically, this PR does not change anything in the bridge's byte code. This PR introduces some improved structure for development.

----

The storage allocation of the deployed bridge contract looks as follows:

```bash
| Name         | Type                                                 | Slot | Offset | Bytes | Contract                                               |
|--------------|------------------------------------------------------|------|--------|-------|--------------------------------------------------------|
| management   | contract IBridgeManagement                           | 0    | 0      | 20    | release/testnet/T3/v1/source/BridgeImpl.sol:BridgeImpl |
| locked       | bool                                                 | 0    | 20     | 1     | release/testnet/T3/v1/source/BridgeImpl.sol:BridgeImpl |
| gasBridge    | struct BridgeStorage.GasBridge                       | 1    | 0      | 320   | release/testnet/T3/v1/source/BridgeImpl.sol:BridgeImpl |
| claimableGas | mapping(uint64 => struct BridgeStorage.GasClaimable) | 11   | 0      | 32    | release/testnet/T3/v1/source/BridgeImpl.sol:BridgeImpl |
```

These slots need to be consistent with the updated contract. The newly added `ReentrencyGuard` brings a new entry `_status` that takes up one slot and thus it can't be extended in first place by the `BridgeStorage.sol`.

> Doing so (i.e., `contract BridgeStorage is ReentrencyGuard`) would put `_status` in slot 1, which would not be compatible with the state of the bridge's proxy on T3.

However, from a development perspective letting `BridgeImpl.sol` extend `ReentrencyGuard` is not nice, since it'll be not so clear how to add potential future storage entries that won't mess with the proxy's existing state. Therefore, this PR introduces an abstraction for this storage slot allocation. I've moved the storage slots that we'll use for the next update on T3 into a new file `BridgeStorageV1.sol` and let `BridgeStorage.sol` extend this contract and then `ReenctrencyGuard` in second place.

If the bridge needs a future update that requires further storage slots, these can be added in a new file (e.g., `BridgeStorageV2.sol`) and then `BridgeStorage.sol` can extend this in third place as to not mess up the proxy's slot allocation.

Just for visualization, here's the slot allocation of current bridge contract. As you can see the first 11 slots are compatible with the already deployed slot allocation as seen above. The newly used slots have the default value and they don't need an initial value to be assigned.

```bash
| Name             | Type                                                                  | Slot | Offset | Bytes | Contract                                   |
|------------------|-----------------------------------------------------------------------|------|--------|-------|--------------------------------------------|
| management       | contract IBridgeManagement                                            | 0    | 0      | 20    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| bridgePaused     | bool                                                                  | 0    | 20     | 1     | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| gasBridge        | struct StorageTypes.GasBridge                                         | 1    | 0      | 320   | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| claimableGas     | mapping(uint256 => struct StorageTypes.Claimable)                     | 11   | 0      | 32    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| unclaimedRewards | uint256                                                               | 12   | 0      | 32    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| tokenBridges     | mapping(address => struct StorageTypes.TokenBridge)                   | 13   | 0      | 32    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| tokenClaimables  | mapping(address => mapping(uint256 => struct StorageTypes.Claimable)) | 14   | 0      | 32    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
| _status          | uint256                                                               | 15   | 0      | 32    | contracts/bridge/BridgeImpl.sol:BridgeImpl |
```