### PR TITLE
Fix UTs for maxFee and fix amount range

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -159,7 +159,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     }
 
     /**
-     * @notice Withdraw Gas to provided address on Neo N3. The provided amount of Gas must have a precision of maximal 8 decimal points due to the GAS token on Neo N3 having 8 decimals.
+     * @notice Withdraw Gas to provided address on Neo N3. The provided amount of Gas after the fee deduction must have a precision of maximal 8 decimal points matching the 8 decimals of the GAS token on Neo N3.
      * @dev When invoking this function provide the amount of Gas to withdraw to Neo N3 as msg.value.
      * @param _to the address to which the Gas should be sent on Neo N3.
      * @param _maxFee the maximum fee that the sender is willing to pay for the withdrawal. If the actual fee is higher than this value, the withdrawal is aborted.
@@ -169,22 +169,25 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         uint256 _maxFee
     ) external payable onlyBridgeUnpaused onlyGasBridgeUnpaused {
         if (_to == address(0)) revert InvalidAddress();
-        uint256 msgValue = msg.value;
-        if ((msgValue % 1e10) != 0) revert InvalidAmount();
         StorageTypes.GasConfig memory config = _getGasBridgeConfig();
         StorageTypes.State memory state = _getGasBridgeWithdrawalState();
-        // Revert if the provided value is outside the allowed range.
-        if (msgValue < config.minAmount)
-            revert AmountBelowMinAmount(config.minAmount, msgValue);
-        if (msgValue > config.maxAmount)
-            revert AmountExceedsMaxAmount(config.maxAmount, msgValue);
+
         // Revert if the actual fee is higher than the provided max fee.
         if (config.fee > _maxFee) revert MaxFeeExceeded(_maxFee, config.fee);
         _addUnclaimedRewards(config.fee);
 
+        uint256 withdrawalAmount = msg.value - config.fee;
+        // Revert if the withdrawal amount is not a multiple of 1e10, matching the 8 decimals of Gas on Neo N3.
+        if ((withdrawalAmount % 1e10) != 0) revert InvalidAmount();
+        // Revert if the withdrawal amount is outside the allowed range.
+        if (withdrawalAmount < config.minAmount)
+            revert AmountBelowMinAmount(config.minAmount, withdrawalAmount);
+        if (withdrawalAmount > config.maxAmount)
+            revert AmountExceedsMaxAmount(config.maxAmount, withdrawalAmount);
+
         // The actual withdrawal amount is the sent value minus the fee.
         uint256 amountForHashing = GasBridgeLib._removeTenDecimals(
-            msgValue - config.fee
+            withdrawalAmount
         );
         uint256 newNonce = state.nonce + 1;
         bytes32 withdrawalHash = GasBridgeLib._hashGasBrideOp(

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -524,7 +524,7 @@ describe("Bridge Implementation", function () {
             const withdrawalFee = (await bridgeContract.gasBridge()).config.fee;
 
             const withdrawData = { nonce: 1, amount: withdrawalAmount + withdrawalFee, to: relayer.address };
-            const tx = await bridgeContract.connect(relayer).withdrawGas(withdrawData.to, { value: withdrawData.amount });
+            const tx = await bridgeContract.connect(relayer).withdrawGas(withdrawData.to, withdrawalFee, { value: withdrawData.amount });
 
             const hashWithdrawData1 = await hashDepositOrWithdrawal(withdrawData.nonce, relayer.address, toNeoDecimals(withdrawalAmount));
             const new_withdrawRoot = await computeRoot(ethers.ZeroHash, hashWithdrawData1);
@@ -543,9 +543,9 @@ describe("Bridge Implementation", function () {
             let withdrawalFee = (await bridgeContract.gasBridge()).config.fee;
 
             const withdrawData1 = { nonce: 1, amount: withdrawalAmount_1, to: relayer.address };
-            await bridgeContract.connect(relayer).withdrawGas(withdrawData1.to, { value: withdrawalAmount_1 + withdrawalFee });
+            await bridgeContract.connect(relayer).withdrawGas(withdrawData1.to, withdrawalFee, { value: withdrawalAmount_1 + withdrawalFee });
             const withdrawData2 = { nonce: 2, amount: withdrawalAmount_2, to: validator1.address };
-            const tx2 = await bridgeContract.connect(relayer).withdrawGas(withdrawData2.to, { value: withdrawalAmount_2 + withdrawalFee });
+            const tx2 = await bridgeContract.connect(relayer).withdrawGas(withdrawData2.to, withdrawalFee, { value: withdrawalAmount_2 + withdrawalFee });
 
             const hashWithdrawData1 = await hashDepositOrWithdrawal(withdrawData1.nonce, relayer.address, toNeoDecimals(withdrawData1.amount));
             const hash1 = await computeRoot(ethers.ZeroHash, hashWithdrawData1);
@@ -562,21 +562,21 @@ describe("Bridge Implementation", function () {
             const { bridgeContract, relayer } = await loadFixture(deployBridgeFixture);
 
             let gasBridge = (await bridgeContract.gasBridge());
-            const withdrawalAmount = gasBridge.config.minAmount + ethers.parseEther("0.00000001");
+            const minWithdrawalAmount = gasBridge.config.minAmount;
             const withdrawalFee = gasBridge.config.fee;
-            const withdrawalAmountWithFee = withdrawalAmount + withdrawalFee;
+            const minWithdrawalAmountWithFee = minWithdrawalAmount + withdrawalFee;
 
-            const withdrawData = { nonce: 1, amount: withdrawalAmount, to: relayer.address };
-            const tx = await bridgeContract.connect(relayer).withdrawGas(withdrawData.to, { value: withdrawalAmountWithFee });
+            const withdrawData = { nonce: 1, amount: minWithdrawalAmount, to: relayer.address };
+            const minTx = await bridgeContract.connect(relayer).withdrawGas(withdrawData.to, withdrawalFee, { value: minWithdrawalAmountWithFee });
 
-            const hashWithdrawData1 = await hashDepositOrWithdrawal(withdrawData.nonce, relayer.address, toNeoDecimals(withdrawalAmount));
+            const hashWithdrawData1 = await hashDepositOrWithdrawal(withdrawData.nonce, relayer.address, toNeoDecimals(minWithdrawalAmount));
             const new_withdrawRoot = await computeRoot(ethers.ZeroHash, hashWithdrawData1);
 
             let withdrawalState = (await bridgeContract.gasBridge()).withdrawalState;
             expect(withdrawalState.nonce).to.be.equal(1);
             expect(withdrawalState.root).to.be.equal(new_withdrawRoot);
-            await expect(tx).to.emit(bridgeContract, "GasWithdrawal").withArgs(1, relayer.address, toNeoDecimals(withdrawData.amount), relayer.address, hashWithdrawData1, new_withdrawRoot);
-            await expect(tx).to.changeEtherBalances([bridgeContract, relayer], [withdrawalAmountWithFee, -withdrawalAmountWithFee]);
+            await expect(minTx).to.emit(bridgeContract, "GasWithdrawal").withArgs(1, relayer.address, toNeoDecimals(withdrawData.amount), relayer.address, hashWithdrawData1, new_withdrawRoot);
+            await expect(minTx).to.changeEtherBalances([bridgeContract, relayer], [minWithdrawalAmountWithFee, -minWithdrawalAmountWithFee]);
         });
 
         it("withdraw with the wrong amount", async function () {
@@ -585,10 +585,10 @@ describe("Bridge Implementation", function () {
             let config = (await bridgeContract.gasBridge()).config;
             const minWithdrawalAmount = config.minAmount;
             const maxWithdrawalAmount = config.maxAmount;
-            const withdrawlFee = config.fee;
-            await expect(invalidAmount).to.be.greaterThanOrEqual(minWithdrawalAmount + withdrawlFee);
-            await expect(invalidAmount).to.be.lessThanOrEqual(maxWithdrawalAmount + withdrawlFee);
-            await expect(bridgeContract.connect(relayer).withdrawGas(relayer, { value: invalidAmount })).to.be.revertedWithCustomError(bridgeContract, "InvalidAmount");
+            const withdrawalFee = config.fee;
+            await expect(invalidAmount).to.be.greaterThanOrEqual(minWithdrawalAmount + withdrawalFee);
+            await expect(invalidAmount).to.be.lessThanOrEqual(maxWithdrawalAmount + withdrawalFee);
+            await expect(bridgeContract.connect(relayer).withdrawGas(relayer, withdrawalFee, { value: invalidAmount })).to.be.revertedWithCustomError(bridgeContract, "InvalidAmount");
         });
 
         it("withdraw is too low", async function () {
@@ -596,9 +596,9 @@ describe("Bridge Implementation", function () {
             const minFraction = ethers.parseEther("0.00000001");
             let config = (await bridgeContract.gasBridge()).config;
             const minWithdrawalAmount = config.minAmount;
-            const withdrawlFee = config.fee;
-            const tooLowWithdrawalAmount = minWithdrawalAmount + withdrawlFee - minFraction;
-            await expect(bridgeContract.connect(relayer).withdrawGas(relayer, { value: tooLowWithdrawalAmount })).to.be.revertedWithCustomError(bridgeContract, "InvalidAmount");
+            const withdrawalFee = config.fee;
+            const tooLowWithdrawalAmount = minWithdrawalAmount + withdrawalFee - minFraction;
+            await expect(bridgeContract.connect(relayer).withdrawGas(relayer, withdrawalFee, { value: tooLowWithdrawalAmount })).to.be.revertedWithCustomError(bridgeContract, "AmountBelowMinAmount");
         });
 
         it("withdraw is too high", async function () {
@@ -607,9 +607,9 @@ describe("Bridge Implementation", function () {
             const minFraction = ethers.parseEther("0.00000001");
             let config = (await bridgeContract.gasBridge()).config;
             const maxWithdrawalAmount = config.maxAmount;
-            const withdrawlFee = config.fee;
-            const tooHighWithdrawalAmount = maxWithdrawalAmount + withdrawlFee + minFraction;
-            await expect(bridgeContract.connect(validator7).withdrawGas(validator6, { value: tooHighWithdrawalAmount })).to.be.revertedWithCustomError(bridgeContract, "InvalidAmount");
+            const withdrawalFee = config.fee;
+            const tooHighWithdrawalAmount = maxWithdrawalAmount + withdrawalFee + minFraction;
+            await expect(bridgeContract.connect(validator7).withdrawGas(validator6, withdrawalFee, { value: tooHighWithdrawalAmount })).to.be.revertedWithCustomError(bridgeContract, "AmountExceedsMaxAmount");
             validator7.sendTransaction({ to: validator6, value: ethers.parseEther("1000") });
         });
 
@@ -623,14 +623,14 @@ describe("Bridge Implementation", function () {
             expect(await bridgeContract.unclaimedRewards()).to.be.equal(0);
 
             const to1 = relayer.address;
-            await bridgeContract.connect(relayer).withdrawGas(to1, { value: withdrawalAmount_1 });
+            await bridgeContract.connect(relayer).withdrawGas(to1, withdrawalFeeBeforeChange, { value: withdrawalAmount_1 });
 
             await bridgeContract.connect(governor).setGasWithdrawalFee(ethers.parseEther("0.5"));
             const withdrawalFeeAfterChange = (await bridgeContract.gasBridge()).config.fee;
             expect(withdrawalFeeAfterChange).to.be.equal(ethers.parseEther("0.5"));
 
             const to2 = funder.address;
-            const tx2 = await bridgeContract.connect(relayer).withdrawGas(to2, { value: withdrawalAmount_2 });
+            const tx2 = await bridgeContract.connect(relayer).withdrawGas(to2, withdrawalFeeAfterChange, { value: withdrawalAmount_2 });
 
             let withdrawalState = (await bridgeContract.gasBridge()).withdrawalState;
             expect(withdrawalState.nonce).to.be.equal(2);
@@ -654,7 +654,9 @@ describe("Bridge Implementation", function () {
 
             await expect(depositTx).to.changeEtherBalances([bridgeContract, Depositdata1.to], [0, 0]);
 
-            let depositState = (await bridgeContract.gasBridge()).depositState;
+            let gasBridge = await bridgeContract.gasBridge();
+            let depositState = gasBridge.depositState;
+            let withdrawalFee = gasBridge.config.fee;
             expect(depositState.nonce).to.equal(depositData.nonce);
             expect(depositState.root).to.equal(new_root);
 
@@ -665,7 +667,7 @@ describe("Bridge Implementation", function () {
 
             // Let's withdraw some eth to increase the contract's balance and make the claim possible.
             const amount = ethers.parseEther("10");
-            const withdrawTx = await bridgeContract.connect(relayer).withdrawGas(relayer.address, { value: amount });
+            const withdrawTx = await bridgeContract.connect(relayer).withdrawGas(relayer.address, withdrawalFee, { value: amount });
             await expect(withdrawTx).to.changeEtherBalances([bridgeContract, relayer.address], [amount, -amount]);
             const bridgeContractBalance = await ethers.provider.getBalance(bridgeContract.target);
             expect(bridgeContractBalance).to.be.greaterThanOrEqual((await bridgeContract.claimableGas(depositData.nonce)).amount);
@@ -779,7 +781,8 @@ describe("Bridge Implementation", function () {
             await expect(bridgeContract.connect(relayer).depositGas(root1, signatures, [Depositdata1])).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
             await expect(bridgeContract.connect(relayer).claimGas(Depositdata1.nonce)).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
             const withdrawData = { nonce: 1, amount: ethers.parseEther("1"), to: relayer.address };
-            await expect(bridgeContract.connect(relayer).withdrawGas(withdrawData.to, { value: withdrawData.amount })).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
+            let withdrawalFee = (await bridgeContract.gasBridge()).config.fee;
+            await expect(bridgeContract.connect(relayer).withdrawGas(withdrawData.to, withdrawalFee, { value: withdrawData.amount })).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
             await expect(bridgeContract.connect(securityGuard).pauseBridge()).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
         });
     });


### PR DESCRIPTION
With this PR, the amount range (i.e., the min and max amounts) is checked against the amount **after** the fee is deducted. This is done, because:

1. Users expect to receive an amount that is meaningful after the fee is deducted. Checking against `msg.value - fee` ensures they are not withdrawing an amount that becomes negligible after the fee deduction.
2. Checking the range against `msg.value - fee` prevents users from sending just enough to pass the minimum threshold before the fee deduction, which could result in very small amounts being withdrawn.
3. This approach is clearer and more transparent for users, as it directly correlates the minimum withdrawal amount to what they will actually receive on Neo N3.

Further, tests have been updated after neglecting doing it in PR #121.