### PR TITLE
Remove `unregisterToken` function

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -247,17 +247,6 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     }
 
     /**
-     * @notice Unregister a token bridge.
-     * @param _neoXToken the address of the token on the Neo X network.
-     */
-    function unregisterToken(
-        address _neoXToken
-    ) external override onlyGovernor onlyTokenBridgePaused(_neoXToken) {
-        _unregisterToken(_neoXToken);
-        emit TokenUnregister(_neoXToken, _getNeoN3Token(_neoXToken));
-    }
-
-    /**
      * @notice Pause a token bridge. No deposits, withdrawals, or claims of a token bridge can be made while it is locked.
      * @param _neoXToken the address of the token on the Neo X network.
      */

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -236,14 +236,6 @@ contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         return tokenBridges[_neoXToken].config.neoN3Token != address(0);
     }
 
-    function _unregisterToken(address _neoXToken) internal {
-        if (!_isRegisteredToken(_neoXToken))
-            revert TokenBridgeNotRegistered(_neoXToken);
-        delete tokenBridges[_neoXToken];
-        // If a token is unregistered, the claimables remain in storage.
-        // This means, that they are locked, and can only ever be retrieved again if there's a new token bridge registration with the same Neo X token address.
-    }
-
     function _pauseToken(address _neoXToken) internal {
         if ((!_isRegisteredToken(_neoXToken)))
             revert TokenBridgeNotRegistered(_neoXToken);

--- a/contracts/interfaces/ITokenBridge.sol
+++ b/contracts/interfaces/ITokenBridge.sol
@@ -9,10 +9,6 @@ interface ITokenBridge {
         address indexed neoXToken,
         StorageTypes.TokenConfig tokenConfig
     );
-    event TokenUnregister(
-        address indexed neoXToken,
-        address indexed neoN3Token
-    );
     event TokenBridgePause(
         address indexed neoXToken,
         address indexed neoN3Token
@@ -73,8 +69,6 @@ interface ITokenBridge {
         address neoXToken,
         StorageTypes.TokenConfig calldata tokenConfig
     ) external;
-
-    function unregisterToken(address neoXToken) external;
 
     function pauseTokenBridge(address neoXToken) external;
 


### PR DESCRIPTION
Resolves #126
Resolves #127

If a token bridge should no longer be supported, it can just be kept in a paused state.