### PR TITLE
Use actual balance increase as amount in token withdrawal

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -485,6 +485,8 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
 
         // Compare the balance before and after the transfer to get the actual received amount. This is necessary if the token contract were to deduct a fee in transfers.
         uint256 bridgeBalanceAfter = erc20Token.balanceOf(address(this));
+        // Revert if there is an underflow.
+        if (bridgeBalanceAfter < bridgeBalanceBefore) revert InvalidTransfer();
         uint256 receivedAmount = bridgeBalanceAfter - bridgeBalanceBefore;
 
         // Check that the received amount is in the allowed range.

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -447,10 +447,10 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
 
     /**
      * @notice Withdraw tokens to Neo N3. Requires that the sender has approved the provided amount to the bridge contract. The fee required for withdrawing that token can be fetched from its config (i.e., tokenBridges[_neoXToken].config.fee). It needs to be payed to this function (i.e., as msg.value).
-     * @dev This function transfers the provided amount of the provided token from the msg.sender to this contract. It requires that the msg.sender has previously approved at least the provided amount to this contract. Further, it computes the new root and updates the token withdrawal state.
+     * @dev This function transfers the provided amount of the provided token from the msg.sender to this contract. It requires that the msg.sender has previously approved at least the provided amount to this contract. Further, it computes the new root and updates the token withdrawal state. Note, that potential fee deductions by a token contract need to be considered when setting the _amount parameter, i.e., the allowed range for amount values is checked against the actual received amount of tokens.
      * @param _neoXToken the address of the token on the Neo X network.
      * @param _to the address to which the tokens should be sent on Neo N3.
-     * @param _amount the amount of tokens to withdraw to Neo N3.
+     * @param _amount the amount of tokens to transfer to the bridge contract in order to withdraw them to Neo N3.
      */
     function withdrawToken(
         address _neoXToken,
@@ -467,16 +467,14 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         if (!_isRegisteredToken(_neoXToken))
             revert TokenBridgeNotRegistered(_neoXToken);
         StorageTypes.TokenConfig memory config = _getTokenConfig(_neoXToken);
-        uint256 tokenAmount = _amount;
-        if (tokenAmount < config.minAmount)
-            revert AmountBelowMinAmount(config.minAmount, tokenAmount);
-        if (tokenAmount > config.maxAmount)
-            revert AmountExceedsMaxAmount(config.maxAmount, tokenAmount);
+
         // Revert if the provided value is lower than the required fee.
         if (msg.value < config.fee)
             revert InsufficientFee(msg.value, config.fee);
         _addUnclaimedRewards(msg.value);
 
+        IERC20 erc20Token = IERC20(_neoXToken);
+        uint256 bridgeBalanceBefore = erc20Token.balanceOf(address(this));
         // Execute the transfer of the tokens from the sender to the bridge contract.
         bool success = IERC20(_neoXToken).transferFrom(
             msg.sender,
@@ -485,15 +483,25 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         );
         if (!success) revert TransferFailed();
 
+        // Compare the balance before and after the transfer to get the actual received amount. This is necessary if the token contract were to deduct a fee in transfers.
+        uint256 bridgeBalanceAfter = erc20Token.balanceOf(address(this));
+        uint256 receivedAmount = bridgeBalanceAfter - bridgeBalanceBefore;
+
+        // Check that the received amount is in the allowed range.
+        if (receivedAmount < config.minAmount)
+            revert AmountBelowMinAmount(config.minAmount, receivedAmount);
+        if (receivedAmount > config.maxAmount)
+            revert AmountExceedsMaxAmount(config.maxAmount, receivedAmount);
+
         // Compute the new root and update the token withdrawal state.
         StorageTypes.State memory state = _getTokenWithdrawalState(_neoXToken);
         uint256 newNonce = state.nonce + 1;
 
         if (config.executionType == StorageTypes.ExecutionType.NEO) {
-            if (tokenAmount % 1e18 != 0) {
+            if (receivedAmount % 1e18 != 0) {
                 revert InvalidAmount();
             }
-            tokenAmount /= 1e18;
+            receivedAmount /= 1e18;
         }
 
         bytes32 withdrawalHash = TokenBridgeLib._hashTokenBridgeOp(
@@ -501,7 +509,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             _neoXToken,
             newNonce,
             _to,
-            tokenAmount
+            receivedAmount
         );
         bytes32 newRoot = BridgeLib._computeNewRoot(state.root, withdrawalHash);
         _setTokenWithdrawalState(
@@ -513,7 +521,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             config.neoN3Token,
             newNonce,
             _to,
-            tokenAmount,
+            receivedAmount,
             msg.sender,
             withdrawalHash,
             newRoot

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -34,6 +34,7 @@ contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     error InvalidFee();
     error InvalidTokenAddress();
     error InvalidTokenConfig();
+    error InvalidTransfer();
     error InvalidNonceSequence();
     error InvalidRoot();
     error InvalidValidatorSignatures();


### PR DESCRIPTION
Resolves #128 

### Context

Based on a raised issue in the security audit (https://github.com/Secure3Audit/findings_NeoX_Bridge_Contract/issues/22), there might be tokens that are designed in a way that they deduct a fee of the to-be-transferred token, leading to a smaller amount received than sent. This PR checks the bridge contract's balance before and after the transfer execution and takes into account the actually received amount for the bridging operation.

Here's part of the statement in the issue:

> This function is used to withdraw tokens to Neo N3 and it requires that the sender has approved the provided amount to the bridge contract, issue however is that when transferring the execution uses the classic IERC20.transferFrom(), however for popular tokens that deduct fees on their transfers, this then causes protocol to not only inflate the amount of tokens received, but some invariants could also be broken.
>
> POC for broken invariant:
>
> Here we are to prove a user can deposit < config.minAmount.
> config.minAmount for the token is set as 10e18.
> User calls on withdraw with 106e17.
> The token's fee for transfers is 10%
> User ends up depositing ~ 95e17 which is < minAmount = 10e18
> As shown by the minimalistic POC, not only is the accounting flawed, but users could as well even break an invariant.