### PR TITLE
Fix uint downcasting in subsequent check

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -74,7 +74,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     {
         StorageTypes.State memory state = _getGasBridgeDepositState();
         StorageTypes.GasConfig memory config = _getGasBridgeConfig();
-        uint depositLength = _deposits.length;
+        uint256 depositLength = _deposits.length;
         if (depositLength == 0) revert InvalidDepositsLength();
         if (depositLength > config.maxDeposits) revert InvalidDepositsLength();
         if (!BridgeLib._subsequentNonces(_deposits, state.nonce))
@@ -104,8 +104,8 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     function _executeGasTransfers(
         BridgeLib.DepositData[] calldata _deposits
     ) private {
-        uint depositLength = _deposits.length;
-        for (uint i = 0; i < depositLength; i++) {
+        uint256 depositLength = _deposits.length;
+        for (uint256 i = 0; i < depositLength; i++) {
             BridgeLib.DepositData calldata depositEntry = _deposits[i];
             address to = depositEntry.to;
             if (BridgeLib._isContract(to)) {
@@ -224,7 +224,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         emit MaxGasWithdrawalChange(_amount);
     }
 
-    function setMaxGasDeposits(uint8 _maxNrDeposits) external onlyGovernor {
+    function setMaxGasDeposits(uint256 _maxNrDeposits) external onlyGovernor {
         _setMaxGasDeposits(_maxNrDeposits);
         emit MaxGasDepositsChange(_maxNrDeposits);
     }
@@ -304,7 +304,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.TokenConfig memory config = _getTokenConfig(_neoXToken);
 
         // Check parameter validity
-        uint depositLength = _deposits.length;
+        uint256 depositLength = _deposits.length;
         if (depositLength == 0) revert InvalidDepositsLength();
         if (depositLength > config.maxDeposits) revert InvalidDepositsLength();
         // Check if provided deposit data's nonces are subsequent to the current nonce and each other.
@@ -351,9 +351,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.ExecutionType _executionType,
         BridgeLib.DepositData[] calldata _deposits
     ) private {
-        uint depositLength = _deposits.length;
+        uint256 depositLength = _deposits.length;
         // Execute the token distribution for each deposit entry
-        for (uint i = 0; i < depositLength; i++) {
+        for (uint256 i = 0; i < depositLength; i++) {
             BridgeLib.DepositData calldata depositEntry = _deposits[i];
             address to = depositEntry.to;
             uint256 transferAmount = depositEntry.amount;
@@ -523,9 +523,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         address[] calldata _neoXTokens,
         uint256[] calldata _fees
     ) external override onlyGovernor {
-        uint nrTokens = _neoXTokens.length;
+        uint256 nrTokens = _neoXTokens.length;
         if (nrTokens != _fees.length) revert LengthMismatch();
-        for (uint i = 0; i < nrTokens; i++) {
+        for (uint256 i = 0; i < nrTokens; i++) {
             uint256 fee = _fees[i];
             _setTokenWithdrawalFee(_neoXTokens[i], fee);
             emit TokenWithdrawalFeeChange(_neoXTokens[i], fee);
@@ -536,9 +536,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         address[] calldata _neoXTokens,
         uint256[] calldata _minAmounts
     ) external override onlyGovernor {
-        uint nrTokens = _neoXTokens.length;
+        uint256 nrTokens = _neoXTokens.length;
         if (nrTokens != _minAmounts.length) revert LengthMismatch();
-        for (uint i = 0; i < nrTokens; i++) {
+        for (uint256 i = 0; i < nrTokens; i++) {
             uint256 minAmount = _minAmounts[i];
             _setTokenMinWithdrawalAmount(_neoXTokens[i], minAmount);
             emit MinTokenWithdrawalAmountChange(_neoXTokens[i], minAmount);
@@ -549,9 +549,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         address[] calldata _neoXTokens,
         uint256[] calldata _maxAmounts
     ) external override onlyGovernor {
-        uint nrTokens = _neoXTokens.length;
+        uint256 nrTokens = _neoXTokens.length;
         if (nrTokens != _maxAmounts.length) revert LengthMismatch();
-        for (uint i = 0; i < nrTokens; i++) {
+        for (uint256 i = 0; i < nrTokens; i++) {
             uint256 maxAmount = _maxAmounts[i];
             _setTokenMaxWithdrawalAmount(_neoXTokens[i], maxAmount);
             emit MaxTokenWithdrawalAmountChange(_neoXTokens[i], maxAmount);
@@ -562,9 +562,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         address[] calldata _neoXTokens,
         uint256[] calldata _maxDeposits
     ) external override onlyGovernor {
-        uint nrTokens = _neoXTokens.length;
+        uint256 nrTokens = _neoXTokens.length;
         if (nrTokens != _maxDeposits.length) revert LengthMismatch();
-        for (uint i = 0; i < nrTokens; i++) {
+        for (uint256 i = 0; i < nrTokens; i++) {
             uint256 maxDeposits = _maxDeposits[i];
             _setMaxTokenDeposits(_neoXTokens[i], maxDeposits);
             emit MaxTokenDepositsChange(_neoXTokens[i], maxDeposits);

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -205,7 +205,7 @@ contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         gasBridge.config.maxAmount = _amount;
     }
 
-    function _setMaxGasDeposits(uint8 _maxDeposits) internal {
+    function _setMaxGasDeposits(uint256 _maxDeposits) internal {
         if (_maxDeposits == 0) revert InvalidAmount();
         gasBridge.config.maxDeposits = _maxDeposits;
     }

--- a/contracts/interfaces/IBridgeManagement.sol
+++ b/contracts/interfaces/IBridgeManagement.sol
@@ -6,7 +6,7 @@ import "../library/BridgeLib.sol";
 interface IBridgeManagement {
     event OwnerChange(address owner);
     event RelayerChange(address relayer);
-    event ValidatorsChange(address[] validators, uint threshold);
+    event ValidatorsChange(address[] validators, uint256 threshold);
     event GovernorChange(address governor);
     event SecurityGuardChange(address securityGuard);
     event FunderChange(address funder);
@@ -17,14 +17,14 @@ interface IBridgeManagement {
 
     function setValidators(
         address[] calldata _validators,
-        uint threshold
+        uint256 threshold
     ) external;
 
     function getValidators() external view returns (address[] memory);
 
-    function getValidator(uint _index) external view returns (address);
+    function getValidator(uint256 _index) external view returns (address);
 
-    function getValidatorThreshold() external view returns (uint);
+    function getValidatorThreshold() external view returns (uint256);
 
     function verifyValidatorSignatures(
         bytes32 _newDepositRoot,

--- a/contracts/interfaces/IGasBridge.sol
+++ b/contracts/interfaces/IGasBridge.sol
@@ -25,7 +25,7 @@ interface IGasBridge {
     event GasWithdrawalFeeChange(uint256 newFee);
     event MinGasWithdrawalChange(uint256 newAmount);
     event MaxGasWithdrawalChange(uint256 amount);
-    event MaxGasDepositsChange(uint8 amount);
+    event MaxGasDepositsChange(uint256 amount);
 
     function pauseGasBridge() external;
 
@@ -47,5 +47,5 @@ interface IGasBridge {
 
     function setMaxGasWithdrawalAmount(uint256 _amount) external;
 
-    function setMaxGasDeposits(uint8 _maxNrDeposits) external;
+    function setMaxGasDeposits(uint256 _maxNrDeposits) external;
 }

--- a/contracts/library/BridgeLib.sol
+++ b/contracts/library/BridgeLib.sol
@@ -20,7 +20,7 @@ library BridgeLib {
         uint256 _startNonce
     ) internal pure returns (bool) {
         uint depositsLength = _deposits.length;
-        for (uint8 i = 1; i <= depositsLength; i++) {
+        for (uint256 i = 1; i <= depositsLength; i++) {
             if (_deposits[i - 1].nonce != _startNonce + i) {
                 return false;
             }

--- a/contracts/library/GasBridgeLib.sol
+++ b/contracts/library/GasBridgeLib.sol
@@ -9,8 +9,8 @@ library GasBridgeLib {
         BridgeLib.DepositData[] calldata _deposits
     ) internal pure returns (bytes32) {
         bytes32 parent = _previousRoot;
-        uint depositsLength = _deposits.length;
-        for (uint i = 0; i < depositsLength; i++) {
+        uint256 depositsLength = _deposits.length;
+        for (uint256 i = 0; i < depositsLength; i++) {
             BridgeLib.DepositData calldata depositData = _deposits[i];
             bytes32 depositHash = _hashGasBrideOp(
                 depositData.nonce,

--- a/contracts/library/ManagementLib.sol
+++ b/contracts/library/ManagementLib.sol
@@ -5,9 +5,9 @@ library ManagementLib {
     function _hasDuplicates(
         address[] memory _addresses
     ) internal pure returns (bool) {
-        uint addressesLength = _addresses.length;
-        for (uint i = 0; i < addressesLength - 1; i++) {
-            for (uint j = i + 1; j < addressesLength; j++) {
+        uint256 addressesLength = _addresses.length;
+        for (uint256 i = 0; i < addressesLength - 1; i++) {
+            for (uint256 j = i + 1; j < addressesLength; j++) {
                 if (_addresses[i] == _addresses[j]) {
                     return true;
                 }

--- a/contracts/library/TokenBridgeLib.sol
+++ b/contracts/library/TokenBridgeLib.sol
@@ -17,9 +17,16 @@ library TokenBridgeLib {
         uint256 _amount,
         address _to
     ) internal returns (bool) {
-        bytes memory transferCall = abi.encodeCall(IERC20.transfer, (_to, _amount));
-        (bool success, bytes memory returndata) = address(_neoXToken).call(transferCall);
-        return success && (returndata.length == 0 || abi.decode(returndata, (bool)));
+        bytes memory transferCall = abi.encodeCall(
+            IERC20.transfer,
+            (_to, _amount)
+        );
+        (bool success, bytes memory returndata) = address(_neoXToken).call(
+            transferCall
+        );
+        return
+            success &&
+            (returndata.length == 0 || abi.decode(returndata, (bool)));
     }
 
     /**
@@ -39,8 +46,8 @@ library TokenBridgeLib {
         BridgeLib.DepositData[] calldata _deposits
     ) internal pure returns (bytes32) {
         bytes32 parent = _previousRoot;
-        uint depositsLength = _deposits.length;
-        for (uint i = 0; i < depositsLength; i++) {
+        uint256 depositsLength = _deposits.length;
+        for (uint256 i = 0; i < depositsLength; i++) {
             BridgeLib.DepositData calldata depositData = _deposits[i];
             bytes32 depositHash = _hashTokenBridgeOp(
                 _neoN3Token,

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -10,7 +10,7 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
     constructor(
         address _owner,
         address _relayer,
-        uint8 _validatorThreshold,
+        uint256 _validatorThreshold,
         address[] memory _validators,
         address _governor,
         address _securityGuard,
@@ -42,16 +42,16 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
             )
         );
         address[] memory recovered = new address[](threshold);
-        for (uint i = 0; i < threshold; i++) {
+        for (uint256 i = 0; i < threshold; i++) {
             BridgeLib.Signature calldata sig = _signatures[i];
             recovered[i] = ECDSA.recover(signedRootMsg, sig.v, sig.r, sig.s);
         }
         // check if all recovered addresses are in the validator set
-        uint covered = 0;
-        uint n = 0;
-        uint j;
-        uint validatorsLength = validators.length;
-        for (uint i = 0; i < threshold; i++) {
+        uint256 covered = 0;
+        uint256 n = 0;
+        uint256 j;
+        uint256 validatorsLength = validators.length;
+        for (uint256 i = 0; i < threshold; i++) {
             for (j = n; j < validatorsLength; j++) {
                 if (recovered[i] == validators[j]) {
                     covered++;
@@ -74,7 +74,7 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
 
     function setValidators(
         address[] calldata _validators,
-        uint threshold
+        uint256 threshold
     ) external onlyOwner {
         _setValidators(_validators, threshold);
         emit ValidatorsChange(_validators, threshold);
@@ -84,11 +84,11 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
         return validators;
     }
 
-    function getValidator(uint _index) external view returns (address) {
+    function getValidator(uint256 _index) external view returns (address) {
         return validators[_index];
     }
 
-    function getValidatorThreshold() external view returns (uint) {
+    function getValidatorThreshold() external view returns (uint256) {
         return validatorThreshold;
     }
 


### PR DESCRIPTION
Fixes #138

Just a minor change. The downcasting to `uint8` is redundant now (the threshold was of type `uint8` previously). Hence, I changed it to `uint256`.

Also, to stay more consistent during development I use `uint256` explicitly instead of `uint`.