### PR TITLE
Use initializer for more consistent development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,7 +123,6 @@ typechain-types/
 
 #foundry
 
-lib/
 cache_forge/
 crytic-export
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/openzeppelin-foundry-upgrades"]
+	path = lib/openzeppelin-foundry-upgrades
+	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -8,11 +8,34 @@ import "../interfaces/ITokenBridge.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
+    function initialize(
+        address _management,
+        uint256 _fee,
+        uint256 _minAmount,
+        uint256 _maxAmount,
+        uint256 _maxDeposits
+    ) public initializer {
+        management = IBridgeManagement(_management);
+        gasBridge = StorageTypes.GasBridge({
+            paused: false,
+            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
+            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
+            config: StorageTypes.GasConfig({
+                fee: _fee,
+                minAmount: _minAmount,
+                maxAmount: _maxAmount,
+                maxDeposits: _maxDeposits
+            })
+        });
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
+
     receive() external payable onlyFunder {
         emit Fund(msg.value);
     }
-
-    constructor(address _management) BridgeStorage(_management) {}
 
     // Contract Pausing
 

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -29,6 +29,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         });
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -12,14 +12,10 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 /**
  * @dev This contract holds errors, modifiers, internal view functions and functions that directly modify the storage. The modification functions have logical checks but no access-checks. For example, registering a token should only be viable if there is no entry for that token already. However, checking if the msg.sender is allowed to do so should be handled in a higher-level contract (i.e., in this case the corresponding Impl contract).
  */
-contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
+abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     address public constant SELF = 0x1212100000000000000000000000000000000004;
     address public constant GOV_ADMIN =
         0x1212000000000000000000000000000000000000;
-
-    constructor(address _management) BridgeStorageV1(_management) {
-        _disableInitializers();
-    }
 
     error AmountBelowMinAmount(uint256 minAmount, uint256 provided);
     error AmountExceedsMaxAmount(uint256 maxAmount, uint256 provided);

--- a/contracts/bridge/BridgeStorageV1.sol
+++ b/contracts/bridge/BridgeStorageV1.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
  * @author BaneLabs
  * @dev This contract holds the storage variables for the Bridge contract and outlines the slot allocations of the contracts storage. Storage slot modifications should be done with care to avoid conflicts with existing storage slots in the proxy.
  */
-contract BridgeStorageV1 is ReentrancyGuard {
+abstract contract BridgeStorageV1 is ReentrancyGuard {
     // Slot 0 is taken by ReentrancyGuard's _status storage value
     // Slots 1-99 remain empty for future upgrades (if further storage extension is needed, e.g., similar to ReentrancyGuard's _status var, this contract can easily be extended and the new var can use the next slot from _gap0, so that the other storage variables can remain in this file)
     uint256[99] private _gap0;
@@ -32,19 +32,4 @@ contract BridgeStorageV1 is ReentrancyGuard {
         public tokenClaimables;
     // Slots 105-113 (9 slots)
     StorageTypes.GasBridge public gasBridge;
-
-    constructor(address _management) {
-        management = IBridgeManagement(_management);
-        gasBridge = StorageTypes.GasBridge({
-            paused: false,
-            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
-            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
-            config: StorageTypes.GasConfig({
-                fee: 1e17,
-                minAmount: 1e18,
-                maxAmount: 1e22,
-                maxDeposits: 100
-            })
-        });
-    }
 }

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -7,7 +7,7 @@ import "../library/BridgeLib.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
-    constructor(
+    function initialize(
         address _owner,
         address _relayer,
         uint256 _validatorThreshold,
@@ -15,17 +15,18 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
         address _governor,
         address _securityGuard,
         address _funder
-    )
-        BridgeManagementStorage(
-            _owner,
-            _relayer,
-            _validatorThreshold,
-            _validators,
-            _governor,
-            _securityGuard,
-            _funder
-        )
-    {}
+    ) public initializer {
+        __Ownable_init(_owner);
+        _setRelayer(_relayer);
+        _setValidators(_validators, _validatorThreshold);
+        _setGovernor(_governor);
+        _setSecurityGuard(_securityGuard);
+        _setFunder(_funder);
+    }
+
+    constructor() {
+        _disableInitializers();
+    }
 
     function verifyValidatorSignatures(
         bytes32 _newDepositRoot,

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -24,6 +24,7 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
         _setFunder(_funder);
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
     }

--- a/contracts/management/BridgeManagementStorage.sol
+++ b/contracts/management/BridgeManagementStorage.sol
@@ -3,32 +3,17 @@ pragma solidity ^0.8.24;
 
 import "../library/ManagementLib.sol";
 import "./BridgeManagementStorageV1.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
  * @dev This contract holds errors, modifiers, internal view functions and functions that directly modify the storage. The modification functions have logical checks but no access-checks. For example, registering a token should only be viable if there is no entry for that token already. However, checking if the msg.sender is allowed to do so should be handled in a higher-level contract (i.e., in this case the corresponding Impl contract).
  */
-contract BridgeManagementStorage is BridgeManagementStorageV1, UUPSUpgradeable {
+abstract contract BridgeManagementStorage is
+    BridgeManagementStorageV1,
+    UUPSUpgradeable
+{
     address public constant SELF = 0x1212100000000000000000000000000000000005;
     address public constant GOV_ADMIN =
         0x1212000000000000000000000000000000000000;
-
-    constructor(
-        address _owner,
-        address _relayer,
-        uint256 _validatorThreshold,
-        address[] memory _validators,
-        address _governor,
-        address _securityGuard,
-        address _funder
-    ) BridgeManagementStorageV1(_owner) {
-        _disableInitializers();
-        _setRelayer(_relayer);
-        _setValidators(_validators, _validatorThreshold);
-        _setGovernor(_governor);
-        _setSecurityGuard(_securityGuard);
-        _setFunder(_funder);
-    }
 
     error InvalidAddress();
     error InvalidValidatorArray();

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -6,10 +6,8 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
-    // Slot 0 is taken by Ownable2Step's _owner storage value
-    // Slot 1 is taken by Ownable2Step's _pendingOwner storage value
-    // Slots 2-99 remain empty for future upgrades (if further storage extension is needed, e.g., similar to ReentrancyGuard's _status var, this contract can easily be extended and the new var can use the next slot from _gap0, so that the other storage variables can remain in this file)
-    uint256[98] private _gap0;
+    // Slots 0-99 remain empty for future upgrades (if further storage extension is needed, e.g., similar to ReentrancyGuard's _status var, this contract can easily be extended and the new var can use the next slot from _gap0, so that the other storage variables can remain in this file)
+    uint256[100] private _gap0;
 
     // Slot 100
     address internal relayer;

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.24;
 
 import "../library/ManagementLib.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts/access/Ownable2Step.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
-contract BridgeManagementStorageV1 is Ownable2Step {
+abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
     // Slot 0 is taken by Ownable2Step's _owner storage value
     // Slot 1 is taken by Ownable2Step's _pendingOwner storage value
     // Slots 2-99 remain empty for future upgrades (if further storage extension is needed, e.g., similar to ReentrancyGuard's _status var, this contract can easily be extended and the new var can use the next slot from _gap0, so that the other storage variables can remain in this file)
@@ -28,6 +28,4 @@ contract BridgeManagementStorageV1 is Ownable2Step {
 
     // Slot 105
     address internal funder;
-
-    constructor(address initialOwner) Ownable(initialOwner) {}
 }

--- a/contracts/tests/MockERC20.sol
+++ b/contracts/tests/MockERC20.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
+
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
-    constructor(string memory name, string memory symbol) ERC20(name, symbol) {
+    constructor(
+        string memory _name,
+        string memory _symbol
+    ) ERC20(_name, _symbol) {
         _mint(msg.sender, 1000000000000000000000000);
     }
 
-    function mint(address to, uint256 amount)  external {
-        _mint(to, amount);
+    function mint(address _to, uint256 _amount) external {
+        _mint(_to, _amount);
     }
 }

--- a/contracts/tests/SigUtils.sol
+++ b/contracts/tests/SigUtils.sol
@@ -1,30 +1,43 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
+
 import "../library/BridgeLib.sol";
 
 contract SigUtils {
-    uint256 internal user0PrivateKey = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
-    uint256 internal user1PrivateKey = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
-    uint256 internal user2PrivateKey = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
-    uint256 internal user3PrivateKey = 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6;
-    uint256 internal user4PrivateKey = 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a;
-    uint256 internal user5PrivateKey = 0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba;
-    uint256 internal user6PrivateKey = 0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e;
+    uint256 internal user0PrivateKey =
+        0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+    uint256 internal user1PrivateKey =
+        0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
+    uint256 internal user2PrivateKey =
+        0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a;
+    uint256 internal user3PrivateKey =
+        0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6;
+    uint256 internal user4PrivateKey =
+        0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a;
+    uint256 internal user5PrivateKey =
+        0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba;
+    uint256 internal user6PrivateKey =
+        0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e;
 
-    uint256 internal valid_user0PrivateKey = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff87;
-    uint256 internal valid_user1PrivateKey = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b786907;
-    uint256 internal valid_user2PrivateKey = 0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab3657;
-    uint256 internal valid_user3PrivateKey = 0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a7;
-    uint256 internal valid_user4PrivateKey = 0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a349267;
-    uint256 internal valid_user5PrivateKey = 0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffb7;
-    uint256 internal valid_user6PrivateKey = 0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec15647;
+    uint256 internal valid_user0PrivateKey =
+        0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff87;
+    uint256 internal valid_user1PrivateKey =
+        0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b786907;
+    uint256 internal valid_user2PrivateKey =
+        0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab3657;
+    uint256 internal valid_user3PrivateKey =
+        0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a7;
+    uint256 internal valid_user4PrivateKey =
+        0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a349267;
+    uint256 internal valid_user5PrivateKey =
+        0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffb7;
+    uint256 internal valid_user6PrivateKey =
+        0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec15647;
 
     // computes the hash of a permit
-    function getStructHash(BridgeLib.DepositData memory _depositData)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function getStructHash(
+        BridgeLib.DepositData memory _depositData
+    ) internal pure returns (bytes32) {
         return
             keccak256(
                 abi.encodePacked(
@@ -35,16 +48,13 @@ contract SigUtils {
             );
     }
 
-    function getSignedHash(bytes32 _hash)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(
-            abi.encodePacked(
-                "\x19Ethereum Signed Message:\n32",
-                keccak256(abi.encodePacked(_hash))
-            )
-        );
+    function getSignedHash(bytes32 _hash) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n32",
+                    keccak256(abi.encodePacked(_hash))
+                )
+            );
     }
 }

--- a/contracts/tests/TestBridge.sol
+++ b/contracts/tests/TestBridge.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
+
 import "../bridge/BridgeImpl.sol";
 
 contract TestBridge is BridgeImpl {
-    constructor(address m) BridgeImpl(m) {}
-
     function isRegisteredToken(address neoXToken) public view returns (bool) {
         return _isRegisteredToken(neoXToken);
     }
@@ -36,7 +35,9 @@ contract TestBridge is BridgeImpl {
         return _getTokenDepositState(neoXToken);
     }
 
-    function getTokenWithdrawalState( address _neoXToken) public view returns (StorageTypes.State memory withdrawalState) {
+    function getTokenWithdrawalState(
+        address _neoXToken
+    ) public view returns (StorageTypes.State memory withdrawalState) {
         return _getTokenWithdrawalState(_neoXToken);
     }
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,7 @@
 [profile.default]
 src = 'contracts'
+build_info = true
+extra_output = ["storageLayout"]
 out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = 'contracts'
 build_info = true
 extra_output = ["storageLayout"]
+fs_permissions = [{ access = "read", path = "./"}]
 out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
         "esprima": "^2.7.3",
         "estraverse": "^1.9.3",
         "esutils": "^2.0.3",
-        "eth-gas-reporter": "^0.2.27",
+        "eth-gas-reporter": "^0.2.25",
         "ethereum-bloom-filters": "^1.0.10",
         "ethereum-cryptography": "^1.2.0",
         "ethereumjs-abi": "^0.6.8",
@@ -2176,80 +2176,6 @@
         "@openzeppelin/contracts": "5.0.2"
       }
     },
-    "node_modules/@openzeppelin/defender-admin-client": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-admin-client/-/defender-admin-client-1.54.1.tgz",
-      "integrity": "sha512-kRpSUdTsnSqntp4FOXIm95t+6VKHc8CUY2Si71VDuxs0q7HSPZkdpRPSntcolwEzWy9L4a8NS/QMwDF5NJ4X1g==",
-      "dev": true,
-      "dependencies": {
-        "@openzeppelin/defender-base-client": "1.54.1",
-        "axios": "^1.4.0",
-        "ethers": "^5.7.2",
-        "lodash": "^4.17.19",
-        "node-fetch": "^2.6.0"
-      }
-    },
-    "node_modules/@openzeppelin/defender-admin-client/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
-    "node_modules/@openzeppelin/defender-base-client": {
-      "version": "1.54.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/defender-base-client/-/defender-base-client-1.54.1.tgz",
-      "integrity": "sha512-DRGz/7KN3ZQwu28YWMOaojrC7jjPkz/uCwkC8/C8B11qwZhA5qIVvyhYHhhFOCl0J84+E3TNdvkPD2q3p2WaJw==",
-      "dev": true,
-      "dependencies": {
-        "amazon-cognito-identity-js": "^6.0.1",
-        "async-retry": "^1.3.3",
-        "axios": "^1.4.0",
-        "lodash": "^4.17.19",
-        "node-fetch": "^2.6.0"
-      }
-    },
     "node_modules/@openzeppelin/defender-sdk-base-client": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/defender-sdk-base-client/-/defender-sdk-base-client-1.11.0.tgz",
@@ -2283,13 +2209,11 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.0.5.tgz",
-      "integrity": "sha512-7Klg1B6fH45+7Zxzr6d9mLqudrL9Uk6CUG5AeG5NckPfP4ZlQRo1squcQ8yJPwqDS8rQjfChiqKDelp4LTjyZQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.2.0.tgz",
+      "integrity": "sha512-xybXIHQIZK2a1HH7ukMToRbIcU9LHfL49gtB0KYptY6f/r9lqrFOupN8aOBueRZW4Ymhc6HGL9bvj7u7t5lDdQ==",
       "dev": true,
       "dependencies": {
-        "@openzeppelin/defender-admin-client": "^1.52.0",
-        "@openzeppelin/defender-base-client": "^1.52.0",
         "@openzeppelin/defender-sdk-base-client": "^1.10.0",
         "@openzeppelin/defender-sdk-deploy-client": "^1.10.0",
         "@openzeppelin/defender-sdk-network-client": "^1.10.0",
@@ -2298,7 +2222,7 @@
         "debug": "^4.1.1",
         "ethereumjs-util": "^7.1.5",
         "proper-lockfile": "^4.1.1",
-        "undici": "^6.0.0"
+        "undici": "^6.11.1"
       },
       "bin": {
         "migrate-oz-cli-project": "dist/scripts/migrate-oz-cli-project.js"
@@ -9291,9 +9215,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "esprima": "^2.7.3",
     "estraverse": "^1.9.3",
     "esutils": "^2.0.3",
-    "eth-gas-reporter": "^0.2.27",
+    "eth-gas-reporter": "^0.2.25",
     "ethereum-bloom-filters": "^1.0.10",
     "ethereum-cryptography": "^1.2.0",
     "ethereumjs-abi": "^0.6.8",

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -1,20 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../lib/forge-std/src/Test.sol";
-import {TestBridge} from "../contracts/tests/TestBridge.sol";
+import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
 import "../contracts/bridge/BridgeStorage.sol";
 import "../contracts/management/BridgeManagementImpl.sol";
 import "../contracts/tests/SigUtils.sol";
 import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract BridgeImplTest is Test, SigUtils {
-    TestBridge bridgeImpl;
+    TestBridge bridgeProxy;
+    address bridgeProxyAddress;
+
     address neoXToken = address(0x6789);
     address neoN3Token = address(0x7892);
     StorageTypes.TokenConfig validConfig;
 
     // set _management
-    BridgeManagementImpl bridgeManagementImpl;
+    address managementProxyAddress;
     SigUtils sigUtils;
     address public owner = 0xBcd4042DE499D14e55001CcbB24a551F3b954096;
     address public funder = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
@@ -25,7 +28,6 @@ contract BridgeImplTest is Test, SigUtils {
     address internal securityGuard = 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720;
 
     function setUp() public {
-        //set  _management
         sigUtils = new SigUtils();
         validatorsAddresses.push(vm.addr(user0PrivateKey));
         validatorsAddresses.push(vm.addr(user1PrivateKey));
@@ -34,18 +36,40 @@ contract BridgeImplTest is Test, SigUtils {
         validatorsAddresses.push(vm.addr(user4PrivateKey));
         validatorsAddresses.push(vm.addr(user5PrivateKey));
         validatorsAddresses.push(vm.addr(user6PrivateKey));
-        bridgeManagementImpl = new BridgeManagementImpl(
-            owner,
-            relayer,
-            7
-            ,
-            validatorsAddresses,
-            governor,
-            securityGuard,
-            funder
+
+        // Allow constructor to bypass the safety check in deployUUPSProxy.
+        // The constructor only contains _disableInitializers() which is safe to bypass.
+        Options memory opts;
+        opts.unsafeAllow = "constructor";
+        // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
+        managementProxyAddress = Upgrades.deployUUPSProxy(
+            "BridgeManagementImpl.sol",
+            abi.encodeCall(
+                BridgeManagementImpl.initialize,
+                (
+                    owner,
+                    relayer,
+                    7,
+                    validatorsAddresses,
+                    governor,
+                    securityGuard,
+                    funder
+                )
+            ),
+            opts
         );
 
-        bridgeImpl = new TestBridge(address(bridgeManagementImpl));
+        // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
+        bridgeProxyAddress = Upgrades.deployUUPSProxy(
+            "TestBridge.sol",
+            abi.encodeCall(
+                BridgeImpl.initialize,
+                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
+            ),
+            opts
+        );
+        bridgeProxy = TestBridge(payable(bridgeProxyAddress));
+
         validConfig = StorageTypes.TokenConfig({
             neoN3Token: neoN3Token,
             fee: 1,
@@ -64,24 +88,24 @@ contract BridgeImplTest is Test, SigUtils {
 
         // Mock the registration of the token
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-        StorageTypes.TokenConfig memory config = bridgeImpl.getTokenConfig(
+        bridgeProxy.registerToken(neoXToken, validConfig);
+        StorageTypes.TokenConfig memory config = bridgeProxy.getTokenConfig(
             neoXToken
         );
 
         // check register token successful result
-        assertEq(config.neoN3Token, neoN3Token);
-        assertEq(config.fee, 1);
-        assertEq(config.minAmount, 100);
-        assertEq(config.maxAmount, 1000);
-        assertEq(config.maxDeposits, 10);
+        assertEq(config.neoN3Token, neoN3Token, "Neo N3 Token");
+        assertEq(config.fee, 1, "Fee");
+        assertEq(config.minAmount, 100, "Min Amount");
+        assertEq(config.maxAmount, 1000, "Max Amount");
+        assertEq(config.maxDeposits, 10, "Max Deposits");
     }
 
     // test case: successful register token bridge
     function test_RegisterTokenWithZeroAddress() public {
         vm.prank(governor);
         vm.expectRevert(BridgeStorage.InvalidTokenAddress.selector);
-        bridgeImpl.registerToken(address(0), validConfig);
+        bridgeProxy.registerToken(address(0), validConfig);
     }
 
     // test case: register token bridge, with an invalid amount, minAmount>maxAmount
@@ -97,7 +121,7 @@ contract BridgeImplTest is Test, SigUtils {
                 maxDeposits: 10,
                 executionType: StorageTypes.ExecutionType.NEO
             });
-        bridgeImpl.registerToken(neoXToken, invalidConfig);
+        bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
 
     // test case: register token bridge, with an invalid Fee:0
@@ -113,7 +137,7 @@ contract BridgeImplTest is Test, SigUtils {
                 maxDeposits: 10,
                 executionType: StorageTypes.ExecutionType.NEO
             });
-        bridgeImpl.registerToken(neoXToken, invalidConfig);
+        bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
 
     // test case: register token bridge, with an invalid minAmount:0
@@ -129,7 +153,7 @@ contract BridgeImplTest is Test, SigUtils {
                 maxDeposits: 10,
                 executionType: StorageTypes.ExecutionType.NEO
             });
-        bridgeImpl.registerToken(neoXToken, invalidConfig);
+        bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
 
     // test case: register token bridge, with an invalid neoN3Token:0 address
@@ -145,13 +169,13 @@ contract BridgeImplTest is Test, SigUtils {
                 maxDeposits: 10,
                 executionType: StorageTypes.ExecutionType.NEO
             });
-        bridgeImpl.registerToken(neoXToken, invalidConfig);
+        bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
 
     // test case: register token bridge, token bridge already registered
     function test_RegisterTokenAlreadyRegistered() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
+        bridgeProxy.registerToken(neoXToken, validConfig);
         vm.expectRevert(
             abi.encodeWithSelector(
                 BridgeStorage.TokenBridgeAlreadyRegistered.selector,
@@ -159,129 +183,54 @@ contract BridgeImplTest is Test, SigUtils {
             )
         );
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig); 
+        bridgeProxy.registerToken(neoXToken, validConfig);
     }
 
     // test case: register token bridge but not governor
     function test_RegisterTokenByNonGovernor() public {
         vm.prank(address(0x456));
         vm.expectRevert("not governor");
-        bridgeImpl.registerToken(neoXToken, validConfig);
-    }
-
-    // test case: successful unregister token bridge, check result and event
-    function test   () public {
-        // Mock the registration of the token
-        vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-
-        // Pause the token bridge
-        vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
-
-        // Verify the token bridge is paused
-        bool tokenBridgePaused= bridgeImpl.getTokenbridgePaused(neoXToken);
-        assertTrue(tokenBridgePaused);
-
-        // Unregister the token, check unregister token successful event
-        vm.expectEmit(true, true, true, true);
-        emit ITokenBridge.TokenUnregister(neoXToken, address(0));
-
-        vm.prank(governor);
-        bridgeImpl.unregisterToken(neoXToken);
-
-        // Verify that the token bridge is unregistered
-        address afterneoXToken = bridgeImpl.getNeoN3Token(neoXToken);
-        assertEq(afterneoXToken, address(0));
-    }
-
-    // test case: unregister token failed, because the token is not unpaused
-    function test_UnregisterTokenWhenNotPaused() public {
-        vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-
-        // Attempt to unregister the token without pausing
-        vm.prank(governor);
-        vm.expectRevert(
-            abi.encodeWithSignature("TokenBridgeUnpaused(address)", neoXToken)
-        );
-        bridgeImpl.unregisterToken(neoXToken);
-    }
-
-    // test case: unregister token bridge but not governor
-    function test_UnregisterTokenByNonGovernor() public {
-        vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-        // Pause the token bridge
-        vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
-
-        // Attempt to unregister the token by non-governor
-        vm.prank(address(0x456));
-        vm.expectRevert("not governor");
-        bridgeImpl.unregisterToken(neoXToken);
-    }
-
-    // test case: unregister token bridge repeat
-    function test_UnregisterTokenWhenRepeat() public {
-        // Mock the registration of the token
-        vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-
-        // Pause the token bridge
-        vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
-
-        // Verify the token bridge is paused
-        bool tokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
-        assertTrue(tokenBridgePaused);
-        vm.prank(governor);
-        bridgeImpl.unregisterToken(neoXToken);
-
-        // repeat unregister token
-        vm.prank(governor);
-        vm.expectRevert(
-            abi.encodeWithSignature("TokenBridgeUnpaused(address)", neoXToken)
-        );
-        bridgeImpl.unregisterToken(neoXToken);
+        bridgeProxy.registerToken(neoXToken, validConfig);
     }
 
     // test case: successful pause token bridge, check result and event
     function testPauseTokenBridge() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-        bool tokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bridgeProxy.registerToken(neoXToken, validConfig);
+        bool tokenBridgePaused = bridgeProxy.getTokenbridgePaused(neoXToken);
         // Ensure the token bridge is unpaused
         assertFalse(tokenBridgePaused);
 
         // check pause token successful event
         vm.expectEmit(true, true, true, true);
-        address afterNeoN3Token = bridgeImpl.getNeoN3Token(neoXToken);
+        address afterNeoN3Token = bridgeProxy.getNeoN3Token(neoXToken);
         emit ITokenBridge.TokenBridgePause(neoXToken, afterNeoN3Token);
 
         // Pause the token bridge
         vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
 
         // Verify the token bridge is paused
-        bool afterTokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bool afterTokenBridgePaused = bridgeProxy.getTokenbridgePaused(
+            neoXToken
+        );
         assertTrue(afterTokenBridgePaused);
     }
 
     // test case: pause token when token is already paused
     function test_PauseTokenBridgeWhenAlreadyPaused() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
+        bridgeProxy.registerToken(neoXToken, validConfig);
         // Pause the token bridge first
         vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
 
         // Attempt to pause the token bridge again
         vm.prank(securityGuard);
         vm.expectRevert(
             abi.encodeWithSignature("TokenBridgePaused(address)", neoXToken)
         );
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
     }
 
     // test case: pause token bridge when token bridge is not registered
@@ -296,7 +245,7 @@ contract BridgeImplTest is Test, SigUtils {
                 unregisteredToken
             )
         );
-        bridgeImpl.pauseTokenBridge(unregisteredToken);
+        bridgeProxy.pauseTokenBridge(unregisteredToken);
     }
 
     // test case: pause token bridge but not securityGuard
@@ -305,34 +254,38 @@ contract BridgeImplTest is Test, SigUtils {
         address nonSecurityGuard = address(0x654);
         vm.prank(nonSecurityGuard);
         vm.expectRevert("not securityGuard");
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
     }
 
     // test case: successful unpause token bridge, check result and event
     function testUnpauseTokenBridge() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-        bool tokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bridgeProxy.registerToken(neoXToken, validConfig);
+        bool tokenBridgePaused = bridgeProxy.getTokenbridgePaused(neoXToken);
         // Ensure the token bridge is unpaused
         assertFalse(tokenBridgePaused);
 
         // Pause the token bridge
         vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
 
         // Verify the token bridge is paused
-        bool afterTokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bool afterTokenBridgePaused = bridgeProxy.getTokenbridgePaused(
+            neoXToken
+        );
         assertTrue(afterTokenBridgePaused);
 
         // unause the token bridge, check unpause token successful event
         vm.expectEmit(true, true, true, true);
-        address afterNeoN3Token = bridgeImpl.getNeoN3Token(neoXToken);
-        emit ITokenBridge.TokenBridgeUnpause(neoXToken,afterNeoN3Token);
+        address afterNeoN3Token = bridgeProxy.getNeoN3Token(neoXToken);
+        emit ITokenBridge.TokenBridgeUnpause(neoXToken, afterNeoN3Token);
 
-        //unause the token bridge, check unpause token successful result 
+        //unause the token bridge, check unpause token successful result
         vm.prank(governor);
-        bridgeImpl.unpauseTokenBridge(neoXToken);
-        bool aftersTokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bridgeProxy.unpauseTokenBridge(neoXToken);
+        bool aftersTokenBridgePaused = bridgeProxy.getTokenbridgePaused(
+            neoXToken
+        );
         assertFalse(aftersTokenBridgePaused);
     }
 
@@ -340,8 +293,8 @@ contract BridgeImplTest is Test, SigUtils {
     function test_UnpauseTokenBridgeWhenNotPaused() public {
         // Ensure the token bridge is not paused
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
-        bool tokenBridgePaused = bridgeImpl.getTokenbridgePaused(neoXToken);
+        bridgeProxy.registerToken(neoXToken, validConfig);
+        bool tokenBridgePaused = bridgeProxy.getTokenbridgePaused(neoXToken);
         // Ensure the token bridge is unpaused
         assertFalse(tokenBridgePaused);
 
@@ -350,7 +303,7 @@ contract BridgeImplTest is Test, SigUtils {
         vm.expectRevert(
             abi.encodeWithSignature("TokenBridgeUnpaused(address)", neoXToken)
         );
-        bridgeImpl.unpauseTokenBridge(neoXToken);
+        bridgeProxy.unpauseTokenBridge(neoXToken);
     }
 
     // test case: unpause token bridge when token bridge is not registered
@@ -363,20 +316,20 @@ contract BridgeImplTest is Test, SigUtils {
                 unregisteredToken
             )
         );
-        bridgeImpl.unpauseTokenBridge(unregisteredToken);
+        bridgeProxy.unpauseTokenBridge(unregisteredToken);
     }
 
     // test case: pause token bridge but not governor
     function test_UnpauseTokenBridgeByNonGovernor() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXToken, validConfig);
+        bridgeProxy.registerToken(neoXToken, validConfig);
         vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXToken);
+        bridgeProxy.pauseTokenBridge(neoXToken);
 
         // Attempt to unpause the token bridge by a non-governor
         address nonGovernor = address(0x222);
         vm.prank(nonGovernor);
         vm.expectRevert("not governor");
-        bridgeImpl.unpauseTokenBridge(neoXToken);
+        bridgeProxy.unpauseTokenBridge(neoXToken);
     }
 }

--- a/test/BridgeManagement.t.sol
+++ b/test/BridgeManagement.t.sol
@@ -4,9 +4,13 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/management/BridgeManagementImpl.sol";
 import "../contracts/tests/SigUtils.sol";
 import "../contracts/library/BridgeLib.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract BridgeManagementImplTest is Test, SigUtils {
-    BridgeManagementImpl bridgeManagementImpl;
+    BridgeManagementImpl managementProxy;
+    address managementProxyAddress;
+
     SigUtils sigUtils;
     address public owner = 0xBcd4042DE499D14e55001CcbB24a551F3b954096;
     address public funder = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
@@ -33,24 +37,49 @@ contract BridgeManagementImplTest is Test, SigUtils {
         validatorsAddresses.push(vm.addr(user5PrivateKey));
         validatorsKeys.push(user6PrivateKey);
         validatorsAddresses.push(vm.addr(user6PrivateKey));
-        bridgeManagementImpl = new BridgeManagementImpl(
-            owner,
-            relayer,
-            7,
-            validatorsAddresses,
-            governor,
-            securityGuard,
-            funder
+
+        // Allow constructor to bypass the safety check in deployUUPSProxy.
+        // The constructor only contains _disableInitializers() which is safe to bypass.
+        Options memory opts;
+        opts.unsafeAllow = "constructor";
+        // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
+        managementProxyAddress = Upgrades.deployUUPSProxy(
+            "BridgeManagementImpl.sol",
+            abi.encodeCall(
+                BridgeManagementImpl.initialize,
+                (
+                    owner,
+                    relayer,
+                    5,
+                    validatorsAddresses,
+                    governor,
+                    securityGuard,
+                    funder
+                )
+            ),
+            opts
         );
+        managementProxy = BridgeManagementImpl(payable(managementProxyAddress));
     }
 
     function testSetOwner() public {
-        assertEq(bridgeManagementImpl.getOwner(), owner);
-        vm.expectRevert(bytes("not owner"));
-        bridgeManagementImpl.setOwner(funder);
+        assertEq(managementProxy.owner(), owner);
+        // vm.expectRevert("not owner");
+        // vm.expectRevert(bytes("not owner"));
+        vm.prank(funder);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Ownable.OwnableUnauthorizedAccount.selector,
+                funder
+            )
+        );
+        managementProxy.transferOwnership(funder);
         vm.prank(owner);
-        bridgeManagementImpl.setOwner(funder);
-        assertEq(bridgeManagementImpl.getOwner(), funder);
+        managementProxy.transferOwnership(funder);
+        assertEq(managementProxy.pendingOwner(), funder);
+        vm.prank(funder);
+        managementProxy.acceptOwnership();
+        assertEq(managementProxy.owner(), funder);
     }
 
     function testVerifyValidatorSignatures() public view {
@@ -72,10 +101,7 @@ contract BridgeManagementImplTest is Test, SigUtils {
             assertEq(recoveredAddr, validatorsAddresses[i]);
         }
         assert(
-            bridgeManagementImpl.verifyValidatorSignatures(
-                _depositRoot,
-                _signatures
-            )
+            managementProxy.verifyValidatorSignatures(_depositRoot, _signatures)
         );
     }
 }

--- a/test/BridgeManagementTest.ts
+++ b/test/BridgeManagementTest.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { ZeroAddress } from "ethers";
 
@@ -20,8 +20,8 @@ describe("Bridge Management", function () {
             deployer,
             funder
         ] = await ethers.getSigners();
-        const BridgeManagementFactory = await ethers.getContractFactory("BridgeManagementImpl");
-        const bridgeManagementImpl = await BridgeManagementFactory.connect(deployer).deploy(
+        const BridgeManagementFactory = (await ethers.getContractFactory("BridgeManagementImpl"));
+        const proxy = await upgrades.deployProxy(BridgeManagementFactory, [
             owner.address,
             relayer.address,
             5,
@@ -29,10 +29,13 @@ describe("Bridge Management", function () {
             governor.address,
             securityGuard.address,
             funder.address
-        );
-        await bridgeManagementImpl.waitForDeployment();
+        ], { kind: "uups", unsafeAllow: ["constructor"] });
+        await proxy.waitForDeployment();
+
+        const bridgeManagementImpl = proxy as BridgeManagementImpl;
+
         return {
-            bridgeManagementImpl: bridgeManagementImpl,
+            bridgeManagementImpl,
             relayer,
             validator1,
             validator2,

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -6,7 +6,6 @@ import {
     to1, to2, to3, to4, to5, to6, to7, to8, to9, to0,
     toEthDecimals, toNeoDecimals, hashDepositOrWithdrawal, computeRoot, validator1, validator2, validator3, validator7
 } from "./helper";
-import { BridgeImpl } from "../typechain-types";
 
 const Depositdata1 = { nonce: 1, to: validator1, amount: 100000000n };
 const Depositdata2 = { nonce: 2, to: validator2, amount: 200000000n };

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -1,12 +1,12 @@
 import { expect } from "chai";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
-import { getContractAddress } from "@ethersproject/address";
 import { getValidatorSignatures } from "../utils/signature-utils";
 import {
     to1, to2, to3, to4, to5, to6, to7, to8, to9, to0,
     toEthDecimals, toNeoDecimals, hashDepositOrWithdrawal, computeRoot, validator1, validator2, validator3, validator7
 } from "./helper";
+import { BridgeImpl } from "../typechain-types";
 
 const Depositdata1 = { nonce: 1, to: validator1, amount: 100000000n };
 const Depositdata2 = { nonce: 2, to: validator2, amount: 200000000n };
@@ -30,8 +30,8 @@ describe("Bridge Implementation", function () {
             funder
         ] = await ethers.getSigners();
 
-        const BridgeManagementFactory = await ethers.getContractFactory("BridgeManagementImpl");
-        const bridgeManagementContract = await BridgeManagementFactory.connect(deployer).deploy(
+        const BridgeManagementFactory = (await ethers.getContractFactory("BridgeManagementImpl"));
+        const bridgeManagementProxy = await upgrades.deployProxy(BridgeManagementFactory, [
             managementOwner.address,
             relayer.address,
             5,
@@ -39,22 +39,21 @@ describe("Bridge Implementation", function () {
             governor.address,
             securityGuard.address,
             funder.address
-        );
+        ], { kind: "uups", unsafeAllow: ["constructor"] });
+        await bridgeManagementProxy.waitForDeployment();
+        const bridgeManagement = bridgeManagementProxy as BridgeManagementImpl;
 
-        const BridgeContract = await ethers.getContractFactory("BridgeImpl");
-        const contractAddress = getContractAddress({
-            from: deployer.address,
-            nonce: await deployer.getNonce(),
-        });
-        // Fund the bridge contract's address before deployment.
-        await funder.sendTransaction({ to: contractAddress, value: ethers.parseEther("80.0") });
+        const BridgeContractFactory = await ethers.getContractFactory("BridgeImpl");
+        const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress(), ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100], { kind: "uups", unsafeAllow: ["constructor"] });
+        await bridgeProxy.waitForDeployment();
+        const bridge = bridgeProxy as BridgeImpl;
 
-        const bridgeContract = await BridgeContract.connect(deployer).deploy(bridgeManagementContract);
-        await bridgeContract.waitForDeployment();
+        // Fund the bridge contract.
+        await funder.sendTransaction({ to: bridge, value: ethers.parseEther("80.0") });
 
         return {
-            bridgeContract,
-            bridgeManagementContract,
+            bridgeContract: bridge,
+            bridgeManagementContract: bridgeManagement,
             relayer,
             validator1,
             validator2,

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../lib/forge-std/src/Test.sol";
-import {TestBridge} from "../contracts/tests/TestBridge.sol";
+import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
 import {IERC20Errors} from "../node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
 import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
 import "../contracts/management/BridgeManagementImpl.sol";
 import "../contracts/tests/SigUtils.sol";
 import "../contracts/tests/MockERC20.sol";
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
 contract TestFungibleToken is Test, SigUtils {
-    TestBridge bridgeImpl;
+    TestBridge bridgeProxy;
+    address managementProxyAddress;
+    address bridgeProxyAddress;
 
     address neoXTokenA;
     address neoXTokenB;
@@ -35,7 +38,6 @@ contract TestFungibleToken is Test, SigUtils {
     address transferUser0 = 0xF3D4D6320dd41f14B8Fa6550a6F33c46c6F44407;
     address transferUser1 = 0x3220a7ee654E1f84f13E8021B7E2b09775E1BDf2;
 
-
     function setUp() public {
         //set _management
         sigUtils = new SigUtils();
@@ -53,17 +55,41 @@ contract TestFungibleToken is Test, SigUtils {
         validatorsAddresses.push(vm.addr(user5PrivateKey));
         validatorsKeys.push(user6PrivateKey);
         validatorsAddresses.push(vm.addr(user6PrivateKey));
-        bridgeManagementImpl = new BridgeManagementImpl(
-            owner,
-            relayer,
-            5,
-            validatorsAddresses,
-            governor,
-            securityGuard,
-            funder
-        );
 
-        bridgeImpl = new TestBridge(address(bridgeManagementImpl));
+        // Allow constructor to bypass the safety check in deployUUPSProxy.
+        // The constructor only contains _disableInitializers() which is safe to bypass.
+        Options memory opts;
+        opts.unsafeAllow = "constructor";
+        // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
+        managementProxyAddress = Upgrades.deployUUPSProxy(
+            "BridgeManagementImpl.sol",
+            abi.encodeCall(
+                BridgeManagementImpl.initialize,
+                (
+                    owner,
+                    relayer,
+                    5,
+                    validatorsAddresses,
+                    governor,
+                    securityGuard,
+                    funder
+                )
+            ),
+            opts
+        );
+        bridgeManagementImpl = BridgeManagementImpl(managementProxyAddress);
+
+        // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
+        bridgeProxyAddress = Upgrades.deployUUPSProxy(
+            "TestBridge.sol",
+            abi.encodeCall(
+                BridgeImpl.initialize,
+                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
+            ),
+            opts
+        );
+        bridgeProxy = TestBridge(payable(bridgeProxyAddress));
+
         neoXTokenA = address(new MockERC20("MockA", "MA"));
         neoXTokenB = address(new MockERC20("MockB", "MB"));
         validConfigA = StorageTypes.TokenConfig({
@@ -82,6 +108,8 @@ contract TestFungibleToken is Test, SigUtils {
             maxDeposits: 2,
             executionType: StorageTypes.ExecutionType.NEO
         });
+
+        // Fund the test accounts with some ether.
         vm.deal(funder, 1 ether);
         vm.deal(owner, 1 ether);
         vm.deal(transferUser0, 1 ether);
@@ -89,7 +117,9 @@ contract TestFungibleToken is Test, SigUtils {
     }
 
     // Get the correct signatures of the five validators
-    function getSignatures(bytes32 _depositRoot) public view returns (BridgeLib.Signature[] memory) {
+    function getSignatures(
+        bytes32 _depositRoot
+    ) public view returns (BridgeLib.Signature[] memory) {
         uint[] memory defaultIndices = new uint[](5);
         for (uint i = 0; i < 5; i++) {
             defaultIndices[i] = i;
@@ -103,9 +133,16 @@ contract TestFungibleToken is Test, SigUtils {
         uint[] memory validatorIndices
     ) public view returns (BridgeLib.Signature[] memory) {
         // Ensure that the length of the validatorIndices array passed in is 5,6,7, otherwise an exception is thrown
-        require(validatorIndices.length==5 || validatorIndices.length==6|| validatorIndices.length==7, "five-seven validator indexes must be provided");
-        
-        BridgeLib.Signature[] memory _signatures = new BridgeLib.Signature[](validatorIndices.length);
+        require(
+            validatorIndices.length == 5 ||
+                validatorIndices.length == 6 ||
+                validatorIndices.length == 7,
+            "five-seven validator indexes must be provided"
+        );
+
+        BridgeLib.Signature[] memory _signatures = new BridgeLib.Signature[](
+            validatorIndices.length
+        );
         bytes32 ethHash = getSignedHash(_depositRoot);
 
         for (uint i = 0; i < validatorIndices.length; i++) {
@@ -116,7 +153,7 @@ contract TestFungibleToken is Test, SigUtils {
                 validatorsKeys[validatorIndex],
                 ethHash
             );
-            
+
             address recoverAddress = ecrecover(ethHash, v, r, s);
             _signatures[i] = BridgeLib.Signature(v, r, s);
             assertEq(recoverAddress, validatorsAddresses[validatorIndex]);
@@ -126,9 +163,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: successful deposit token, token type is ERC20, Let's call it deposit token A, takes the signatures of the first 5 validators，and check the event
     function testDepositTokenA() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -143,8 +180,8 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -155,13 +192,13 @@ contract TestFungibleToken is Test, SigUtils {
         vm.prank(relayer);
         // check event
         vm.expectEmit(true, true, true, true);
-        emit ITokenBridge.TokenDepositRootUpdate(           
+        emit ITokenBridge.TokenDepositRootUpdate(
             address(neoXTokenA),
             address(neoN3TokenA),
             d1.nonce,
             tokenDepositRoot
         );
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -176,11 +213,11 @@ contract TestFungibleToken is Test, SigUtils {
     function testDepositTokenB() public {
         // Verify the signatures of 6 validators
         vm.prank(owner);
-        bridgeManagementImpl.setValidators(validatorsAddresses,6);
+        bridgeManagementImpl.setValidators(validatorsAddresses, 6);
 
-        MockERC20(neoXTokenB).mint(address(bridgeImpl), 1000 ether);
+        MockERC20(neoXTokenB).mint(address(bridgeProxy), 1000 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenB, validConfigB);
+        bridgeProxy.registerToken(neoXTokenB, validConfigB);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -195,8 +232,8 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenB).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenB).root,
             neoN3TokenB,
             neoXTokenB,
             depositData
@@ -214,14 +251,14 @@ contract TestFungibleToken is Test, SigUtils {
             validatorIndices
         );
         vm.prank(relayer);
-        // check event 
-        emit ITokenBridge.TokenDepositRootUpdate(           
+        // check event
+        emit ITokenBridge.TokenDepositRootUpdate(
             address(neoXTokenB),
             address(neoN3TokenB),
             d1.nonce,
             tokenDepositRoot
         );
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenB,
             tokenDepositRoot,
             signatures,
@@ -236,9 +273,9 @@ contract TestFungibleToken is Test, SigUtils {
     function testClaimTokenA() public {
         // Verify the signatures of 7 validators
         vm.prank(owner);
-        bridgeManagementImpl.setValidators(validatorsAddresses,7);
+        bridgeManagementImpl.setValidators(validatorsAddresses, 7);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -253,15 +290,15 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
         );
         // seven validator participate in the verification
         uint[] memory validatorIndices = new uint[](7);
-        for(uint i = 0 ; i<validatorIndices.length; i++){
+        for (uint i = 0; i < validatorIndices.length; i++) {
             validatorIndices[i] = i;
         }
         BridgeLib.Signature[] memory signatures = getSignatures(
@@ -269,7 +306,7 @@ contract TestFungibleToken is Test, SigUtils {
             validatorIndices
         );
         vm.prank(relayer);
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -279,38 +316,38 @@ contract TestFungibleToken is Test, SigUtils {
         assertEq(MockERC20(neoXTokenA).balanceOf(transferUser1), 0);
 
         // test case: claim token A nonce 1 successful
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 199);
-        bridgeImpl.claimToken(neoXTokenA, 1);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 199);
+        bridgeProxy.claimToken(neoXTokenA, 1);
         assertEq(MockERC20(neoXTokenA).balanceOf(transferUser0), 199);
-        
+
         // test case: claim token A nonce 2 failed, bridge have not enough token
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.TransferFailed.selector)
         );
-        bridgeImpl.claimToken(neoXTokenA, 2);
+        bridgeProxy.claimToken(neoXTokenA, 2);
 
         // test case: claim token A nonce 2 successful
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 299);
-        bridgeImpl.claimToken(neoXTokenA, 2);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 299);
+        bridgeProxy.claimToken(neoXTokenA, 2);
         assertEq(MockERC20(neoXTokenA).balanceOf(transferUser1), 299);
-       
-        // test case: claim token A not exit nonce 3 failed 
+
+        // test case: claim token A not exit nonce 3 failed
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.NonexistentClaimable.selector)
         );
-        bridgeImpl.claimToken(neoXTokenA, 3);
+        bridgeProxy.claimToken(neoXTokenA, 3);
 
         // test case:non-repeatable claim token
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.NonexistentClaimable.selector)
         );
-        bridgeImpl.claimToken(neoXTokenA, 1);
+        bridgeProxy.claimToken(neoXTokenA, 1);
     }
 
     // some test case, token type is NEO, Let's call it claim token B, takes the signatures of the random 5 validators
     function testClaimTokenB() public {
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenB, validConfigB);
+        bridgeProxy.registerToken(neoXTokenB, validConfigB);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -325,8 +362,8 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenB).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenB).root,
             neoN3TokenB,
             neoXTokenB,
             depositData
@@ -342,7 +379,7 @@ contract TestFungibleToken is Test, SigUtils {
             tokenDepositRoot
         );
         vm.prank(relayer);
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenB,
             tokenDepositRoot,
             signatures,
@@ -352,74 +389,80 @@ contract TestFungibleToken is Test, SigUtils {
         assertEq(MockERC20(neoXTokenB).balanceOf(transferUser1), 0);
 
         // test case: claim token B nonce 1 successful
-        MockERC20(neoXTokenB).mint(address(bridgeImpl), 438 ether);
-        bridgeImpl.claimToken(neoXTokenB, 1);
+        MockERC20(neoXTokenB).mint(address(bridgeProxy), 438 ether);
+        bridgeProxy.claimToken(neoXTokenB, 1);
         assertEq(MockERC20(neoXTokenB).balanceOf(transferUser0), 438 ether);
 
         // test case: claim token B nonce 2 failed, bridge have not enough token
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.TransferFailed.selector)
         );
-        bridgeImpl.claimToken(neoXTokenB, 2);
+        bridgeProxy.claimToken(neoXTokenB, 2);
 
         // test case: claim token B nonce 2 successful
-        MockERC20(neoXTokenB).mint(address(bridgeImpl), 439 ether);
-        bridgeImpl.claimToken(neoXTokenB, 2);
+        MockERC20(neoXTokenB).mint(address(bridgeProxy), 439 ether);
+        bridgeProxy.claimToken(neoXTokenB, 2);
         assertEq(MockERC20(neoXTokenB).balanceOf(transferUser1), 439 ether);
 
-        // test case: claim token B not exit nonce 3 failed 
+        // test case: claim token B not exit nonce 3 failed
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.NonexistentClaimable.selector)
         );
-        bridgeImpl.claimToken(neoXTokenB, 3);
+        bridgeProxy.claimToken(neoXTokenB, 3);
 
         // test case:non-repeatable claim token
         vm.expectRevert(
             abi.encodeWithSelector(BridgeStorage.NonexistentClaimable.selector)
         );
-        bridgeImpl.claimToken(neoXTokenB, 1);
+        bridgeProxy.claimToken(neoXTokenB, 1);
     }
 
     // test case: successful withdraw token, token type is ERC20, Let's call it withdraw token A
     function testWithdrawTokenA() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         uint balance = 1000;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         MockERC20(neoXTokenA).mint(transferUser1, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         vm.prank(transferUser1);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser1, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser1,
+                address(bridgeProxy)
+            ),
             balance
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             neoXTokenA,
             transferUser0,
             666
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             neoXTokenA,
             transferUser0,
             111
         );
         vm.prank(transferUser1);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
-            neoXTokenA, 
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
+            neoXTokenA,
             transferUser1,
             777
         );
         vm.prank(transferUser1);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             neoXTokenA,
             transferUser1,
             111
@@ -430,44 +473,50 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: successful withdraw token, token type is NEO, Let's call it withdraw token B
     function testWithdrawTokenB() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenB), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenB), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenB, validConfigB);
+        bridgeProxy.registerToken(neoXTokenB, validConfigB);
         uint balance = 1000 ether;
         MockERC20(neoXTokenB).mint(transferUser0, balance);
         MockERC20(neoXTokenB).mint(transferUser1, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenB).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenB).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenB).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenB).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         vm.prank(transferUser1);
-        MockERC20(neoXTokenB).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenB).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenB).allowance(transferUser1, address(bridgeImpl)),
+            MockERC20(neoXTokenB).allowance(
+                transferUser1,
+                address(bridgeProxy)
+            ),
             balance
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser0,
             135 ether
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser0,
             165 ether
         );
         vm.prank(transferUser1);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser1,
             337 ether
         );
         vm.prank(transferUser1);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser1,
             363 ether
@@ -475,13 +524,19 @@ contract TestFungibleToken is Test, SigUtils {
 
         vm.prank(transferUser1);
         vm.expectRevert(BridgeStorage.InvalidAmount.selector);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser1,
             1 ether + 100
         );
-        assertEq(MockERC20(neoXTokenB).balanceOf(transferUser0), balance - 300 ether);
-        assertEq(MockERC20(neoXTokenB).balanceOf(transferUser1), balance - 700 ether);
+        assertEq(
+            MockERC20(neoXTokenB).balanceOf(transferUser0),
+            balance - 300 ether
+        );
+        assertEq(
+            MockERC20(neoXTokenB).balanceOf(transferUser1),
+            balance - 700 ether
+        );
     }
 
     // Get the error signatures of the five validators
@@ -519,9 +574,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: successful withdraw token, token type is NEO, Let's call it withdraw token B
     function test_DepositTokenWithInvalidNonceSequence() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -537,8 +592,8 @@ contract TestFungibleToken is Test, SigUtils {
         depositData[0] = d0;
         depositData[1] = d1;
 
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -548,7 +603,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidNonceSequence()"));
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -558,9 +613,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: deposit token failed when DepositRoot is invalid
     function test_DepositTokenWithInvalidRoot() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -575,8 +630,8 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -589,7 +644,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidRoot()"));
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             invalidRoot,
             signatures,
@@ -599,9 +654,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: deposit token failed when signatures is invalid
     function test_DepositTokenWithInvalidSignatures() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
 
@@ -619,8 +674,8 @@ contract TestFungibleToken is Test, SigUtils {
         depositData[0] = d0;
         depositData[1] = d1;
 
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -635,7 +690,7 @@ contract TestFungibleToken is Test, SigUtils {
         vm.expectRevert(
             abi.encodeWithSignature("InvalidValidatorSignatures()")
         );
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -645,9 +700,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: deposit token failed because it is not relayer
     function test_DepositTokenByNonRelayer() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -662,8 +717,8 @@ contract TestFungibleToken is Test, SigUtils {
         });
         depositData[0] = d0;
         depositData[1] = d1;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -673,7 +728,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(address(0x9541)); // Non-relayer address
         vm.expectRevert("not relayer");
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -683,13 +738,13 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: deposit token failed when depositData is null
     function test_DepositTokenWithInvalidLength() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](0); // Invalid length
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -699,7 +754,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidDepositsLength()"));
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -709,9 +764,9 @@ contract TestFungibleToken is Test, SigUtils {
 
     // Test case: Deposit token failed when depositData length exceeds bridge configuration
     function test_DepositTokenWithExceedMaxDeposits() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](3);
         BridgeLib.DepositData memory d0 = BridgeLib.DepositData({
@@ -732,8 +787,8 @@ contract TestFungibleToken is Test, SigUtils {
         depositData[0] = d0;
         depositData[1] = d1;
         depositData[2] = d2;
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -743,7 +798,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(relayer);
         vm.expectRevert(abi.encodeWithSignature("InvalidDepositsLength()"));
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -753,13 +808,13 @@ contract TestFungibleToken is Test, SigUtils {
 
     // Test case: Deposit token failed when token is paused
     function test_DepositTokenWithTokenBridgepaused() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         vm.prank(securityGuard);
-        bridgeImpl.pauseTokenBridge(neoXTokenA);
+        bridgeProxy.pauseTokenBridge(neoXTokenA);
         // Verify the token bridge is paused
-        bool tokenBridgePaused= bridgeImpl.getTokenbridgePaused(neoXTokenA);
+        bool tokenBridgePaused = bridgeProxy.getTokenbridgePaused(neoXTokenA);
         assertTrue(tokenBridgePaused);
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
@@ -776,8 +831,8 @@ contract TestFungibleToken is Test, SigUtils {
         depositData[0] = d0;
         depositData[1] = d1;
 
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -789,7 +844,7 @@ contract TestFungibleToken is Test, SigUtils {
         vm.expectRevert(
             abi.encodeWithSignature("TokenBridgePaused(address)", neoXTokenA)
         );
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -799,14 +854,14 @@ contract TestFungibleToken is Test, SigUtils {
 
     // Test case: Deposit token failed when bridge is paused
     function test_DepositTokenWithbridgePaused() public {
-        MockERC20(neoXTokenA).mint(address(bridgeImpl), 100 ether);
+        MockERC20(neoXTokenA).mint(address(bridgeProxy), 100 ether);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
-        assertFalse(bridgeImpl.getbridgePaused());
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
+        assertFalse(bridgeProxy.getbridgePaused());
 
         vm.prank(securityGuard);
-        bridgeImpl.pauseBridge();
-        assertTrue(bridgeImpl.getbridgePaused());
+        bridgeProxy.pauseBridge();
+        assertTrue(bridgeProxy.getbridgePaused());
 
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);
@@ -823,8 +878,8 @@ contract TestFungibleToken is Test, SigUtils {
         depositData[0] = d0;
         depositData[1] = d1;
 
-        bytes32 tokenDepositRoot = bridgeImpl.computeTokenRoot(
-            bridgeImpl.getTokenDepositState(neoXTokenA).root,
+        bytes32 tokenDepositRoot = bridgeProxy.computeTokenRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
             neoN3TokenA,
             neoXTokenA,
             depositData
@@ -834,7 +889,7 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(relayer);
         vm.expectRevert(abi.encodeWithSignature("BridgePaused()"));
-        bridgeImpl.depositToken(
+        bridgeProxy.depositToken(
             neoXTokenA,
             tokenDepositRoot,
             signatures,
@@ -842,76 +897,99 @@ contract TestFungibleToken is Test, SigUtils {
         );
         vm.prank(governor);
 
-        bridgeImpl.unpauseBridge();
-        assertFalse(bridgeImpl.getbridgePaused());
+        bridgeProxy.unpauseBridge();
+        assertFalse(bridgeProxy.getbridgePaused());
     }
 
-    // test case: withdraw token failed when insufficient fee 
+    // test case: withdraw token failed when insufficient fee
     function testWithdrawToken_InsufficientFee() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         uint balance = 1000;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
-        // Set an insufficient fee 
+        // Set an insufficient fee
         uint256 providedFee = validConfigA.fee - 1;
         vm.expectRevert(
-            abi.encodeWithSignature("InsufficientFee(uint256,uint256)",providedFee,validConfigA.fee)
+            abi.encodeWithSignature(
+                "InsufficientFee(uint256,uint256)",
+                providedFee,
+                validConfigA.fee
+            )
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: providedFee}(
+        bridgeProxy.withdrawToken{value: providedFee}(
             neoXTokenA,
             transferUser0,
             100
         );
     }
 
-    // test case: withdraw token failed when amount < minAmount 
+    // test case: withdraw token failed when amount < minAmount
     function testWithdrawToken_InvalidAmount_LessThanMin() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         uint balance = 1000;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         uint256 amount = validConfigA.minAmount - 1;
-        vm.expectRevert(abi.encodeWithSignature("InvalidAmount()"));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BridgeStorage.AmountBelowMinAmount.selector,
+                [validConfigA.minAmount, amount]
+            )
+        );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             address(neoXTokenA),
             transferUser0,
             amount
         );
     }
 
-    // test case: withdraw token failed when amount > maxAmount 
+    // test case: withdraw token failed when amount > maxAmount
     function testWithdrawToken_InvalidAmount_MoreThanMaxl() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
-        uint balance = 1000;
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
+        uint balance = 1001;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         uint256 amount = validConfigA.maxAmount + 1;
-        vm.expectRevert(abi.encodeWithSignature("InvalidAmount()"));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                BridgeStorage.AmountExceedsMaxAmount.selector,
+                [validConfigA.maxAmount, amount]
+            )
+        );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             address(neoXTokenA),
             transferUser0,
             amount
@@ -920,23 +998,31 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case: withdraw token failed when amount > approveAmount
     function testWithdrawToken_TransferFailed() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         uint balance = 1000;
-        uint approveAmount = 100 ;
+        uint approveAmount = 100;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), approveAmount);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), approveAmount);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             approveAmount
         );
         vm.expectRevert(
-            abi.encodeWithSignature("ERC20InsufficientAllowance(address,uint256,uint256)",address(bridgeImpl),approveAmount,balance)
+            abi.encodeWithSignature(
+                "ERC20InsufficientAllowance(address,uint256,uint256)",
+                address(bridgeProxy),
+                approveAmount,
+                balance
+            )
         );
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             address(neoXTokenA),
             transferUser0,
             balance
@@ -946,8 +1032,13 @@ contract TestFungibleToken is Test, SigUtils {
     // test case:withdraw token failed when token bridge not registered
     function testWithdrawToken_UnregisteredToken() public {
         MockERC20 unregisteredToken = new MockERC20("MockA", "MA");
-        vm.expectRevert(abi.encodeWithSignature("TokenBridgeNotRegistered(address)",address(unregisteredToken)));
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "TokenBridgeNotRegistered(address)",
+                address(unregisteredToken)
+            )
+        );
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             address(unregisteredToken),
             transferUser0,
             100
@@ -956,37 +1047,43 @@ contract TestFungibleToken is Test, SigUtils {
 
     // test case:  withdraw token B failed , token type is NEO,tokenvalue < 1e18
     function testWithdrawTokenB_TransferFailed() public {
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenB), false);
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenB), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenB, validConfigB);
+        bridgeProxy.registerToken(neoXTokenB, validConfigB);
         uint balance = 1000 ether;
         MockERC20(neoXTokenB).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenB).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenB).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenB).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenB).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         vm.expectRevert(abi.encodeWithSignature("InvalidAmount()"));
         vm.prank(transferUser0);
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser0,
-            1000000 
+            1000000
         );
     }
 
-    // test case: Check the event that withdraw token A succeeds 
-    function testWithdrawATokenEvent() public{
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenA), false);
+    // test case: Check the event that withdraw token A succeeds
+    function testWithdrawATokenEvent() public {
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenA, validConfigA);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
         uint balance = 1000;
         MockERC20(neoXTokenA).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenA).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenA).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         // caculate withdrawalHash
@@ -998,11 +1095,14 @@ contract TestFungibleToken is Test, SigUtils {
             342
         );
         // caculate newRoot
-        bytes32 newRoot = BridgeLib._computeNewRoot(bridgeImpl.getTokenDepositState(neoXTokenA).root, withdrawalHash);
+        bytes32 newRoot = BridgeLib._computeNewRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenA).root,
+            withdrawalHash
+        );
         // check withdraw token event
         vm.prank(transferUser0);
         vm.expectEmit(true, true, true, true);
-        emit ITokenBridge.TokenWithdrawal(           
+        emit ITokenBridge.TokenWithdrawal(
             address(neoXTokenA),
             address(neoN3TokenA),
             1,
@@ -1011,26 +1111,28 @@ contract TestFungibleToken is Test, SigUtils {
             transferUser0,
             withdrawalHash,
             newRoot
-
         );
-        bridgeImpl.withdrawToken{value: validConfigA.fee}(
+        bridgeProxy.withdrawToken{value: validConfigA.fee}(
             neoXTokenA,
             transferUser0,
             342
         );
     }
 
-    // test case: Check the event that withdraw token B succeeds 
-    function testWithdrawBTokenEvent() public{
-        assertEq(bridgeImpl.isRegisteredToken(neoXTokenB), false);
+    // test case: Check the event that withdraw token B succeeds
+    function testWithdrawBTokenEvent() public {
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenB), false);
         vm.prank(governor);
-        bridgeImpl.registerToken(neoXTokenB, validConfigB);
+        bridgeProxy.registerToken(neoXTokenB, validConfigB);
         uint balance = 1000 ether;
         MockERC20(neoXTokenB).mint(transferUser0, balance);
         vm.prank(transferUser0);
-        MockERC20(neoXTokenB).approve(address(bridgeImpl), balance);
+        MockERC20(neoXTokenB).approve(address(bridgeProxy), balance);
         assertEq(
-            MockERC20(neoXTokenB).allowance(transferUser0, address(bridgeImpl)),
+            MockERC20(neoXTokenB).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
             balance
         );
         // caculate withdrawalHash
@@ -1039,14 +1141,17 @@ contract TestFungibleToken is Test, SigUtils {
             neoXTokenB,
             1,
             transferUser0,
-            233 
+            233
         );
         // caculate newRoot
-        bytes32 newRoot = BridgeLib._computeNewRoot(bridgeImpl.getTokenDepositState(neoXTokenB).root, withdrawalHash);
+        bytes32 newRoot = BridgeLib._computeNewRoot(
+            bridgeProxy.getTokenDepositState(neoXTokenB).root,
+            withdrawalHash
+        );
         // check withdraw token event
         vm.prank(transferUser0);
         vm.expectEmit(true, true, true, true);
-        emit ITokenBridge.TokenWithdrawal(           
+        emit ITokenBridge.TokenWithdrawal(
             address(neoXTokenB),
             address(neoN3TokenB),
             1,
@@ -1056,7 +1161,7 @@ contract TestFungibleToken is Test, SigUtils {
             withdrawalHash,
             newRoot
         );
-        bridgeImpl.withdrawToken{value: validConfigB.fee}(
+        bridgeProxy.withdrawToken{value: validConfigB.fee}(
             neoXTokenB,
             transferUser0,
             233 ether


### PR DESCRIPTION
The contracts previously did not use any initializer logic due to the fact that the contracts are native contracts. The constructors were only used for testing since they are not included in the deployed byte code.

This added some complexity as it was not so clear which parts are essential for the proxy and which parts are essential for the implementation (`_disableInitializers()`). With this PR, the contracts now follow the usual structure of upgradeable contracts regardless of the fact that they will be native contracts. This improves the readability of the code and lowers future endeavors if the contracts should be upgraded once Neo X launched and the initial contract version is included in the genesis file.

For reviewing, here are some notes (@txhsl):
- I've now used OZ's `Ownable2StepUpgradeable` instead of `Ownable2Step`. The main change of this is that the storage slot of the `_owner` and the `_pendingOwner` is now not appended directly, but has a special slot (see [OwnableStorageLocation](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/625fb3c2b2696f1747ba2e72d1e1113066e6c177/contracts/access/OwnableUpgradeable.sol#L28C55-L28C121)). Hence, the minor change in keeping 100 empty slots in commit https://github.com/bane-labs/bridge-evm-contracts/commit/0862f9154f91de109b53dd20c76c995b5989baab.
- The initializer of `BridgeImpl` includes now the initial variables of the gas bridge to be set as well, such as `fee`, `minAmount`, ... https://github.com/bane-labs/bridge-evm-contracts/blob/15ff54a8c5060906d236114f71bfac875bfebd2c/contracts/bridge/BridgeImpl.sol#L11-L17
- The main changes in the tests are the setups. Apart from that there's some formatting, renaming and the removal of the now redundant tests for unregistering token bridges.