### PR TITLE
Fix requirements for min and max amount

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -265,8 +265,6 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.TokenConfig calldata _tokenConfig
     ) external override onlyGovernor {
         if (_neoXToken == address(0)) revert InvalidTokenAddress();
-        if (_tokenConfig.minAmount > _tokenConfig.maxAmount)
-            revert InvalidAmount();
         if (_tokenConfig.neoN3Token == address(0)) revert InvalidAddress();
 
         _registerToken(_neoXToken, _tokenConfig);

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -253,7 +253,7 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         address _neoXToken,
         uint256 _amount
     ) internal {
-        if (_amount > tokenBridges[_neoXToken].config.maxAmount)
+        if (_amount >= tokenBridges[_neoXToken].config.maxAmount)
             revert InvalidAmount();
         tokenBridges[_neoXToken].config.minAmount = _amount;
     }
@@ -262,7 +262,7 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         address _neoXToken,
         uint256 _amount
     ) internal {
-        if (_amount < tokenBridges[_neoXToken].config.minAmount)
+        if (_amount <= tokenBridges[_neoXToken].config.minAmount)
             revert InvalidAmount();
         tokenBridges[_neoXToken].config.maxAmount = _amount;
     }

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -109,9 +109,9 @@ contract BridgeImplTest is Test, SigUtils {
     }
 
     // test case: register token bridge, with an invalid amount, minAmount>maxAmount
-    function test_RegisterTokenWithInvalidAmount() public {
+    function test_RegisterTokenWithInvalidConfig() public {
         vm.prank(governor);
-        vm.expectRevert(BridgeStorage.InvalidAmount.selector);
+        vm.expectRevert(BridgeStorage.InvalidTokenConfig.selector);
         StorageTypes.TokenConfig memory invalidConfig = StorageTypes
             .TokenConfig({
                 neoN3Token: neoN3Token,


### PR DESCRIPTION
Fixes #142

Additionally to #142, a redundant check was removed, since the case is already covered in the underlying call to `_isValidConfig()`.