### PR TITLE
Refund excess `msg.value`

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -476,31 +476,20 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.TokenConfig memory config = _getTokenConfig(_neoXToken);
 
         // Revert if the provided value is lower than the required fee.
-        if (msg.value < config.fee)
-            revert InsufficientFee(config.fee, msg.value);
-        _addUnclaimedRewards(msg.value);
+        uint256 fee = config.fee;
+        if (msg.value < fee) revert InsufficientFee(fee, msg.value);
+        // Refund the sender if the provided value is higher than the required fee.
+        if (msg.value > fee) {
+            _refund(msg.sender, msg.value - fee);
+        }
+        _addUnclaimedRewards(fee);
 
-        IERC20 erc20Token = IERC20(_neoXToken);
-        uint256 bridgeBalanceBefore = erc20Token.balanceOf(address(this));
-        // Execute the transfer of the tokens from the sender to the bridge contract.
-        bool success = IERC20(_neoXToken).transferFrom(
-            msg.sender,
-            address(this),
-            _amount
+        uint256 receivedAmount = _executeERC20Transfer(
+            _neoXToken,
+            _amount,
+            config.minAmount,
+            config.maxAmount
         );
-        if (!success) revert TransferFailed();
-
-        // Compare the balance before and after the transfer to get the actual received amount. This is necessary if the token contract were to deduct a fee in transfers.
-        uint256 bridgeBalanceAfter = erc20Token.balanceOf(address(this));
-        // Revert if there is an underflow.
-        if (bridgeBalanceAfter < bridgeBalanceBefore) revert InvalidTransfer();
-        uint256 receivedAmount = bridgeBalanceAfter - bridgeBalanceBefore;
-
-        // Check that the received amount is in the allowed range.
-        if (receivedAmount < config.minAmount)
-            revert AmountBelowMinAmount(config.minAmount, receivedAmount);
-        if (receivedAmount > config.maxAmount)
-            revert AmountExceedsMaxAmount(config.maxAmount, receivedAmount);
 
         // Compute the new root and update the token withdrawal state.
         StorageTypes.State memory state = _getTokenWithdrawalState(_neoXToken);
@@ -535,6 +524,41 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             withdrawalHash,
             newRoot
         );
+    }
+
+    function _refund(address _to, uint256 _amount) private {
+        (bool success, ) = _to.call{value: _amount}("");
+        if (!success) revert TransferFailed();
+    }
+
+    function _executeERC20Transfer(
+        address _neoXToken,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint256 _maxAmount
+    ) private returns (uint256 actualReceivedAmount) {
+        IERC20 erc20Token = IERC20(_neoXToken);
+        uint256 bridgeBalanceBefore = erc20Token.balanceOf(address(this));
+        // Execute the transfer of the tokens from the sender to the bridge contract.
+        bool success = IERC20(_neoXToken).transferFrom(
+            msg.sender,
+            address(this),
+            _amount
+        );
+        if (!success) revert TransferFailed();
+
+        // Compare the balance before and after the transfer to get the actual received amount. This is necessary if the token contract were to deduct a fee in transfers.
+        uint256 bridgeBalanceAfter = erc20Token.balanceOf(address(this));
+        // Revert if there is an underflow.
+        if (bridgeBalanceAfter < bridgeBalanceBefore) revert InvalidTransfer();
+        uint256 receivedAmount = bridgeBalanceAfter - bridgeBalanceBefore;
+
+        // Check that the received amount is in the allowed range.
+        if (receivedAmount < _minAmount)
+            revert AmountBelowMinAmount(_minAmount, receivedAmount);
+        if (receivedAmount > _maxAmount)
+            revert AmountExceedsMaxAmount(_maxAmount, receivedAmount);
+        return receivedAmount;
     }
 
     function setTokenWithdrawalFee(

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -488,16 +488,8 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     {
         if (_to == address(0)) revert InvalidAddress();
         StorageTypes.TokenConfig memory config = _getTokenConfig(_neoXToken);
-        // Revert if the provided value is lower than the required fee.
-        uint256 fee = config.fee;
         address from = msg.sender;
-        if (msg.value < fee) revert InsufficientFee(fee, msg.value);
-        // Refund the sender if the provided value is higher than the required fee.
-        if (msg.value > fee) {
-            (bool success, ) = payable(from).call{value: msg.value - fee}("");
-            if (!success) revert TransferFailed();
-        }
-        _addUnclaimedRewards(fee);
+        _processTokenWithdrawalFee(from, msg.value, config.fee);
 
         uint256 receivedAmount = _transferERC20TokenToBridge(
             _neoXToken,
@@ -543,6 +535,32 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             withdrawalHash,
             newRoot
         );
+    }
+
+    /**
+     * @dev Checks the provided value against the required fee. If the provided value exceeds the required fee, the
+     * excess amount is refunded if the sender is an EOA. Otherwise, if the sender is a contract, it is reverted.
+     * @param _from the sender.
+     * @param _msgValue the value sent with the transaction.
+     * @param _fee the required fee.
+     */
+    function _processTokenWithdrawalFee(
+        address _from,
+        uint256 _msgValue,
+        uint256 _fee
+    ) private {
+        // Revert if the provided value is lower than the required fee.
+        if (_msgValue < _fee) revert InsufficientFee(_fee, _msgValue);
+        // Refund the sender (only EOAs) if the provided value is higher than the required fee.
+        if (_msgValue > _fee) {
+            // Revert if the sender is a contract.
+            if (BridgeLib._isContract(_from)) {
+                revert ExactFeeRequired(_fee, _msgValue);
+            }
+            (bool success, ) = payable(_from).call{value: _msgValue - _fee}("");
+            if (!success) revert TransferFailed();
+        }
+        _addUnclaimedRewards(_fee);
     }
 
     function _transferERC20TokenToBridge(

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -480,16 +480,21 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         if (msg.value < fee) revert InsufficientFee(fee, msg.value);
         // Refund the sender if the provided value is higher than the required fee.
         if (msg.value > fee) {
-            _refund(msg.sender, msg.value - fee);
+            (bool success, ) = _to.call{value: msg.value - fee}("");
+            if (!success) revert TransferFailed();
         }
         _addUnclaimedRewards(fee);
 
-        uint256 receivedAmount = _executeERC20Transfer(
+        uint256 receivedAmount = _transferERC20TokenToBridge(
             _neoXToken,
-            _amount,
-            config.minAmount,
-            config.maxAmount
+            msg.sender,
+            _amount
         );
+        // Check that the received amount is in the allowed range.
+        if (receivedAmount < config.minAmount)
+            revert AmountBelowMinAmount(config.minAmount, receivedAmount);
+        if (receivedAmount > config.maxAmount)
+            revert AmountExceedsMaxAmount(config.maxAmount, receivedAmount);
 
         // Compute the new root and update the token withdrawal state.
         StorageTypes.State memory state = _getTokenWithdrawalState(_neoXToken);
@@ -526,22 +531,16 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         );
     }
 
-    function _refund(address _to, uint256 _amount) private {
-        (bool success, ) = _to.call{value: _amount}("");
-        if (!success) revert TransferFailed();
-    }
-
-    function _executeERC20Transfer(
+    function _transferERC20TokenToBridge(
         address _neoXToken,
-        uint256 _amount,
-        uint256 _minAmount,
-        uint256 _maxAmount
+        address _from,
+        uint256 _amount
     ) private returns (uint256 actualReceivedAmount) {
         IERC20 erc20Token = IERC20(_neoXToken);
         uint256 bridgeBalanceBefore = erc20Token.balanceOf(address(this));
         // Execute the transfer of the tokens from the sender to the bridge contract.
         bool success = IERC20(_neoXToken).transferFrom(
-            msg.sender,
+            _from,
             address(this),
             _amount
         );
@@ -552,12 +551,6 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         // Revert if there is an underflow.
         if (bridgeBalanceAfter < bridgeBalanceBefore) revert InvalidTransfer();
         uint256 receivedAmount = bridgeBalanceAfter - bridgeBalanceBefore;
-
-        // Check that the received amount is in the allowed range.
-        if (receivedAmount < _minAmount)
-            revert AmountBelowMinAmount(_minAmount, receivedAmount);
-        if (receivedAmount > _maxAmount)
-            revert AmountExceedsMaxAmount(_maxAmount, receivedAmount);
         return receivedAmount;
     }
 

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -490,17 +490,18 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.TokenConfig memory config = _getTokenConfig(_neoXToken);
         // Revert if the provided value is lower than the required fee.
         uint256 fee = config.fee;
+        address from = msg.sender;
         if (msg.value < fee) revert InsufficientFee(fee, msg.value);
         // Refund the sender if the provided value is higher than the required fee.
         if (msg.value > fee) {
-            (bool success, ) = _to.call{value: msg.value - fee}("");
+            (bool success, ) = payable(from).call{value: msg.value - fee}("");
             if (!success) revert TransferFailed();
         }
         _addUnclaimedRewards(fee);
 
         uint256 receivedAmount = _transferERC20TokenToBridge(
             _neoXToken,
-            msg.sender,
+            from,
             _amount
         );
         // Check that the received amount is in the allowed range.
@@ -538,7 +539,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             newNonce,
             _to,
             receivedAmount,
-            msg.sender,
+            from,
             withdrawalHash,
             newRoot
         );

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -21,6 +21,7 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     error AmountExceedsMaxAmount(uint256 maxAmount, uint256 provided);
     error BridgePaused();
     error BridgeUnpaused();
+    error ExactFeeRequired(uint256 feeExpected, uint256 feeProvided);
     error GasBridgePaused();
     error GasBridgeUnpaused();
     error InsufficientFee(uint256 minExpected, uint256 provided);

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -934,6 +934,41 @@ contract TestFungibleToken is Test, SigUtils {
         );
     }
 
+    // test case: withdraw token with too high fee - refunded
+    function testWithdrawToken_refundExcessFee() public {
+        assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);
+        vm.prank(governor);
+        bridgeProxy.registerToken(neoXTokenA, validConfigA);
+        uint256 balance = 1000;
+        MockERC20(neoXTokenA).mint(transferUser0, balance);
+        vm.prank(transferUser0);
+        MockERC20(neoXTokenA).approve(address(bridgeProxy), balance);
+        assertEq(
+            MockERC20(neoXTokenA).allowance(
+                transferUser0,
+                address(bridgeProxy)
+            ),
+            balance
+        );
+        // Set an excess fee
+        uint256 excessFee = 0.5 ether;
+        uint256 providedFee = validConfigA.fee + excessFee;
+        uint256 gasBalanceBridgeBefore = address(bridgeProxy).balance;
+
+        vm.prank(transferUser0);
+        bridgeProxy.withdrawToken{value: providedFee}(
+            neoXTokenA,
+            transferUser0,
+            100
+        );
+
+        assertEq(
+            address(bridgeProxy).balance,
+            gasBalanceBridgeBefore + validConfigA.fee
+        );
+        assertEq(bridgeProxy.unclaimedRewards(), validConfigA.fee);
+    }
+
     // test case: withdraw token failed when amount < minAmount
     function testWithdrawToken_InvalidAmount_LessThanMin() public {
         assertEq(bridgeProxy.isRegisteredToken(neoXTokenA), false);


### PR DESCRIPTION
Fixes #160 
Fixes #161

I ran into a `stack too deep` compilation error. Therefore, I had to extract some code from the `withdrawToken()` function, i.e., the ERC20 transfer is now in a separate function `_transferERC20TokenToBridge()`.