### PR TITLE
Use `keccak256` instead of `sha256` for computing deposit/withdrawal roots

### DIFF
--- a/contracts/library/BridgeLib.sol
+++ b/contracts/library/BridgeLib.sol
@@ -32,7 +32,7 @@ library BridgeLib {
         bytes32 _formerRoot,
         bytes32 _depositHash
     ) internal pure returns (bytes32) {
-        return sha256(abi.encodePacked(_formerRoot, _depositHash));
+        return keccak256(abi.encodePacked(_formerRoot, _depositHash));
     }
 
     function _isContract(address _addr) internal view returns (bool) {

--- a/contracts/library/GasBridgeLib.sol
+++ b/contracts/library/GasBridgeLib.sol
@@ -27,7 +27,7 @@ library GasBridgeLib {
         address _to,
         uint256 _amount
     ) internal pure returns (bytes32) {
-        return sha256(abi.encodePacked(_nonce, _to, _amount));
+        return keccak256(abi.encodePacked(_nonce, _to, _amount));
     }
 
     // Adds 10 decimals to the amount. GasToken originally has 8 decimals and on this chain it has 18 decimals.

--- a/contracts/library/TokenBridgeLib.sol
+++ b/contracts/library/TokenBridgeLib.sol
@@ -92,7 +92,7 @@ library TokenBridgeLib {
         uint256 _value
     ) internal pure returns (bytes32) {
         return
-            sha256(
+            keccak256(
                 abi.encodePacked(_neoN3Token, _neoXToken, _nonce, _to, _value)
             );
     }

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -208,9 +208,9 @@ describe("Bridge Implementation", function () {
 
             const hashDepositData1 = await hashDepositOrWithdrawal(nonce, to, amount);
             // Raw deposit hash and root from deposit computed on Neo N3 bridge contract
-            expect(hashDepositData1).to.be.equal("0x20aad97e2860b1934184ffb2b04ea45d49af5145fa43cb212027f9e8e728baea");
+            expect(hashDepositData1).to.be.equal("0x7ed36781b8366a590ce568db6712d377c031b9f1a21c44cda2493182b0ff92e5");
             const root1 = await computeRoot(ethers.ZeroHash, hashDepositData1);
-            expect(root1).to.be.equal("0xdda77cac690580c1e5220d377cd807b4d2ed89751e4078525ee54297182d3d88");
+            expect(root1).to.be.equal("0x70789f5bdb108a6b6dc7d7aa0d31649ab5fa980bbbfd1868eb17821b1f61e0ac");
 
             const encodeRoot1 = ethers.solidityPackedKeccak256(["bytes32"], [root1]);
             const signatures = await getValidatorSignatures(ethers.getBytes(encodeRoot1), [1, 2, 3, 4, 5]);
@@ -229,13 +229,13 @@ describe("Bridge Implementation", function () {
             const amount2 = 100000000n;
 
             const hashDepositData1 = await hashDepositOrWithdrawal(nonce1, to1, amount1);
-            expect(hashDepositData1).to.be.equal("0x20aad97e2860b1934184ffb2b04ea45d49af5145fa43cb212027f9e8e728baea");
+            expect(hashDepositData1).to.be.equal("0x7ed36781b8366a590ce568db6712d377c031b9f1a21c44cda2493182b0ff92e5");
             const hashDepositData2 = await hashDepositOrWithdrawal(nonce2, to2, amount2);
-            expect(hashDepositData2).to.be.equal("0x983b3a1ee6b74a5ba07109966f86189d2adf108a25fd9b456030f684bffa8f84");
+            expect(hashDepositData2).to.be.equal("0xcba84a7e0f42d61e4510f0b13ae53c138cb1864b97f598d273c9fb3a9fe8d51a");
             const root1 = await computeRoot(ethers.ZeroHash, hashDepositData1);
-            expect(root1).to.be.equal("0xdda77cac690580c1e5220d377cd807b4d2ed89751e4078525ee54297182d3d88");
+            expect(root1).to.be.equal("0x70789f5bdb108a6b6dc7d7aa0d31649ab5fa980bbbfd1868eb17821b1f61e0ac");
             const new_root = await computeRoot(root1, hashDepositData2);
-            expect(new_root).to.be.equal("0xa33a32b7b710705118b37d5fa7684a26e63840e7b5b88326177e7ec4ee7be253");
+            expect(new_root).to.be.equal("0xa15d5e4d94b19c1c4c8aa07157bb03a121e5b886c76e5ec7cecab139eb342236");
             const new_encodeRoot = ethers.solidityPackedKeccak256(["bytes32"], [new_root]);
             const signatures = await getValidatorSignatures(ethers.getBytes(new_encodeRoot), [1, 2, 3, 4, 5]);
 

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -190,11 +190,11 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             concatenated,
             hex"Ef4073A0F2b305a38EC4050e4d3d28bC40eA63F55615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f0000000000000000000000000000000000000000000000000000000000050b04D44304966f6e74cfd0E2215649D5C57892BfBAaB00000000000000000000000000000000000000000000000000000000499602d2"
         );
-        bytes32 expected = sha256(concatenated);
+        bytes32 expected = keccak256(concatenated);
         assertEq(hashedBridgeOp, expected);
         assertEq(
             hashedBridgeOp,
-            hex"5dcc8d59cfb9446288dc79f3e2a776d05e7bce0b82efe28ec554d6dcb08acda4"
+            hex"5df56ac9c1a3c018a83c763c211f89c7c5c5dc4b121c960452f8cfe802cdc631"
         );
     }
 
@@ -260,7 +260,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         assertEq(neoXNeoTokenContract.balanceOf(recipientOnNeoX_2), 445 ether);
         assertEq(
             tokenDepositRoot,
-            0x6c995cd010e797f62716b58053fbfbf4834c68d96c5f0361bf49186cbef6d457
+            0x30bd66fcd30d5e4759d2a5af3833f418c2960e3552bf93e9f296b433257b2134
         );
     }
 
@@ -305,7 +305,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         assertEq(state.nonce, 3);
         assertEq(
             state.root,
-            0x2b1eb8388620f2ba81eeecda0b88c41a35d8aef678cb1eb22ecc488b087d9c99
+            0xe7bcedec3503f013e96c2656b3ea841f62787a06afd3a3df004635ec9a1432e7
         );
     }
 }

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -46,10 +46,10 @@ export async function fundContract(contract: any, funder: HardhatEthersSigner) {
 
 export async function hashDepositOrWithdrawal(nonce: number, to: string, amount: bigint): Promise<string> {
     const packData = ethers.solidityPacked(["uint256", "address", "uint256"], [nonce, to, amount]);
-    const hashData = ethers.sha256(packData);
+    const hashData = ethers.keccak256(packData);
     return hashData;
 }
 
 export async function computeRoot(previouRoot: string, newHash: string): Promise<string> {
-    return ethers.sha256(ethers.solidityPacked(["bytes32", "bytes32"], [ethers.getBytes(previouRoot), ethers.getBytes(newHash)]));
+    return ethers.keccak256(ethers.solidityPacked(["bytes32", "bytes32"], [ethers.getBytes(previouRoot), ethers.getBytes(newHash)]));
 }


### PR DESCRIPTION
Resolves #73

Must be merged in combination with https://github.com/bane-labs/bridge-neo-contracts/pull/127.