### PR TITLE
Allow the governor to pause

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -42,7 +42,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
 
     // Contract Pausing
 
-    function pauseBridge() external onlySecurityGuard onlyBridgeUnpaused {
+    function pauseBridge() external onlyGovernorOrSecurityGuard onlyBridgeUnpaused {
         _pauseBridge();
         emit BridgePause();
     }
@@ -57,7 +57,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     function pauseGasBridge()
         external
         override
-        onlySecurityGuard
+        onlyGovernorOrSecurityGuard
         onlyGasBridgeUnpaused
     {
         _pauseGasBridge();
@@ -284,7 +284,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
     )
         external
         override
-        onlySecurityGuard
+        onlyGovernorOrSecurityGuard
         onlyIfTokenRegistered(_neoXToken)
         onlyTokenBridgeUnpaused(_neoXToken)
     {

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -38,6 +38,7 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     error InvalidValue();
     error LengthMismatch();
     error MaxFeeExceeded(uint256 maxFeeAllowed, uint256 actualFee);
+    error NoAuthorization();
     error NonexistentClaimable();
     error TokenBridgeAlreadyRegistered(address neoXToken);
     error TokenBridgePaused(address neoXToken);
@@ -57,11 +58,11 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         _;
     }
 
-    modifier onlySecurityGuard() {
-        require(
-            msg.sender == management.getSecurityGuard(),
-            "not securityGuard"
-        );
+    modifier onlyGovernorOrSecurityGuard() {
+        if (
+            msg.sender != management.getGovernor() &&
+                msg.sender != management.getSecurityGuard()
+        ) revert NoAuthorization();
         _;
     }
 

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -254,7 +254,7 @@ contract BridgeImplTest is Test, SigUtils {
         // Attempt to pause the token bridge by a non-security guard
         address nonSecurityGuard = address(0x654);
         vm.prank(nonSecurityGuard);
-        vm.expectRevert("not securityGuard");
+        vm.expectRevert(BridgeStorage.NoAuthorization.selector);
         bridgeProxy.pauseTokenBridge(neoXToken);
     }
 

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -744,8 +744,8 @@ describe("Bridge Implementation", function () {
         });
     });
 
-    describe("Lock Function", async function () {
-        it("Lock with SecurityGuard Account and Unlock with Governor", async function () {
+    describe("Pausing", async function () {
+        it("Pause with Governor or security guard and unpause with governor", async function () {
             const { bridgeContract, validator1, governor, securityGuard } = await loadFixture(deployBridgeFixture);
 
             await bridgeContract.connect(securityGuard).pauseBridge();
@@ -757,18 +757,33 @@ describe("Bridge Implementation", function () {
             expect(await bridgeContract.bridgePaused()).to.equal(false);
         });
 
-        it("Cannot unlock contract if it's already unlocked", async function () {
+        it("Can only pause if governor or security guard", async function () {
+            const { bridgeContract, validator1, governor, securityGuard } = await loadFixture(deployBridgeFixture);
+
+            await expect(bridgeContract.connect(validator1).pauseBridge()).to.be.revertedWithCustomError(bridgeContract, "NoAuthorization");
+            expect(await bridgeContract.bridgePaused()).to.equal(false);
+            
+            await bridgeContract.connect(governor).pauseBridge();
+            expect(await bridgeContract.bridgePaused()).to.equal(true);
+            await bridgeContract.connect(governor).unpauseBridge();
+            expect(await bridgeContract.bridgePaused()).to.equal(false);
+            await bridgeContract.connect(securityGuard).pauseBridge();
+            expect(await bridgeContract.bridgePaused()).to.equal(true);
+            await bridgeContract.connect(governor).unpauseBridge();
+        });
+
+        it("Cannot unpause contract if it's already unpaused", async function () {
             const { bridgeContract, governor } = await loadFixture(deployBridgeFixture);
             await expect(bridgeContract.connect(governor).unpauseBridge()).to.be.revertedWithCustomError(bridgeContract, "BridgeUnpaused");
         });
 
-        it("Cannot lock contract if it's locked", async function () {
+        it("Cannot pause contract if it's paused already", async function () {
             const { bridgeContract, securityGuard } = await loadFixture(deployBridgeFixture);
             await expect(bridgeContract.connect(securityGuard).pauseBridge()).to.emit(bridgeContract, "BridgePause");
             await expect(bridgeContract.connect(securityGuard).pauseBridge()).to.be.revertedWithCustomError(bridgeContract, "BridgePaused");
         });
 
-        it("Cannot deposit, claim or withdraw Gas if contract is locked", async function () {
+        it("Cannot deposit, claim or withdraw Gas if contract is paused", async function () {
             const { bridgeContract, relayer, securityGuard } = await loadFixture(deployBridgeFixture);
             await bridgeContract.connect(securityGuard).pauseBridge()
 


### PR DESCRIPTION
The security guard is intended to guard the bridge if something goes wrong with the bridge and it is intended to act fast to pause and halt any interaction with the bridge involving asset transfers (e.g., parameter changes or registrations are allowed).

If the contract needs to be paused due to some maintenance off-chain or to prepare for a logic contract update, it shouldn't require the security guard to act upon it. Hence, the governor should be allowed to pause to cover those scenarios.