### PR TITLE
Add decimal scaling factor

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -408,12 +408,16 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         );
 
         // Execute the token distribution
-        _executeTokenDistribution(_neoXToken, config.executionType, _deposits);
+        _executeTokenDistribution(
+            _neoXToken,
+            config.decimalScalingFactor,
+            _deposits
+        );
     }
 
     function _executeTokenDistribution(
         address _neoXToken,
-        StorageTypes.ExecutionType _executionType,
+        uint8 _decimalScalingFactor,
         BridgeLib.DepositData[] calldata _deposits
     ) private {
         uint256 depositLength = _deposits.length;
@@ -422,14 +426,9 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             BridgeLib.DepositData calldata depositEntry = _deposits[i];
             address to = depositEntry.to;
             uint256 transferAmount = depositEntry.amount;
-            if (_executionType == StorageTypes.ExecutionType.NEO) {
-                // For NEO tokens, the transfer value needs to be extended with 18 decimals, since it's nondivisible on Neo N3 and it has 18 decimals on Neo X.
-                transferAmount *= 1e18;
+            if (_decimalScalingFactor > 0) {
+                transferAmount *= (10 ** _decimalScalingFactor);
             }
-            assert(
-                _executionType == StorageTypes.ExecutionType.NEO ||
-                    _executionType == StorageTypes.ExecutionType.ERC20
-            );
             bool success = TokenBridgeLib._safeERC20Transfer(
                 IERC20(_neoXToken),
                 to,
@@ -530,11 +529,12 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
         StorageTypes.State memory state = _getTokenWithdrawalState(_neoXToken);
         uint256 newNonce = state.nonce + 1;
 
-        if (config.executionType == StorageTypes.ExecutionType.NEO) {
-            if (receivedAmount % 1e18 != 0) {
+        if (config.decimalScalingFactor > 0) {
+            uint256 scalingFactor = 10 ** config.decimalScalingFactor;
+            if (receivedAmount % scalingFactor != 0) {
                 revert InvalidAmount();
             }
-            receivedAmount /= 1e18;
+            receivedAmount /= scalingFactor;
         }
 
         bytes32 withdrawalHash = TokenBridgeLib._hashTokenBridgeOp(

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -417,7 +417,7 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
 
     function _executeTokenDistribution(
         address _neoXToken,
-        uint8 _decimalScalingFactor,
+        uint256 _decimalScalingFactor,
         BridgeLib.DepositData[] calldata _deposits
     ) private {
         uint256 depositLength = _deposits.length;

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -313,12 +313,6 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         return tokenBridges[_neoXToken].config;
     }
 
-    function _getExecutionType(
-        address _neoXToken
-    ) internal view returns (StorageTypes.ExecutionType) {
-        return tokenBridges[_neoXToken].config.executionType;
-    }
-
     function _getTokenDepositState(
         address _neoXToken
     ) internal view returns (StorageTypes.State memory state) {

--- a/contracts/library/StorageTypes.sol
+++ b/contracts/library/StorageTypes.sol
@@ -36,17 +36,6 @@ library StorageTypes {
 
     // Token Bridges
 
-    /**
-     * The execution type is used to specifies the behaviour when executing a token distribution from another chain.
-     * Currently, there's only two types of a token distribution, which both use a simple ERC20's "transfer(address,uint256)" function, while the type NEO additionally adds 18 decimal places when depositing, since Neo does not have decimal places on Neo N3.
-     * How the distribution handling for other types will be implemented is still under discussion. However, for ERC721, the functions in mind are "mint(address,uint256)", "safeMint(address,uint256)", "transferFrom(address,uint256)" or "safeTransferFrom(address,uint256)". As seen from these function declarations, similar to ERC20, they all use the same parameter types, i.e., besides the function call, the complete existing execution logic and chain computation can be reused in depositToken().
-     */
-    enum ExecutionType {
-        NEO,
-        ERC20
-        // ERC721
-    }
-
     struct TokenBridge {
         bool paused;
         State depositState;
@@ -56,11 +45,12 @@ library StorageTypes {
 
     struct TokenConfig {
         address neoN3Token;
+        // The decimal scaling factor should be used if the token on this chain has more decimal precision than the token on the other chain.
+        // For example, if the token on this chain has 18 decimals and the token on the other chain has 8 decimals, the decimal scaling factor should be 10.
+        uint8 decimalScalingFactor;
         uint256 fee;
         uint256 minAmount;
         uint256 maxAmount;
         uint256 maxDeposits;
-        // Execution details
-        ExecutionType executionType;
     }
 }

--- a/contracts/library/StorageTypes.sol
+++ b/contracts/library/StorageTypes.sol
@@ -45,12 +45,12 @@ library StorageTypes {
 
     struct TokenConfig {
         address neoN3Token;
-        // The decimal scaling factor should be used if the token on this chain has more decimal precision than the token on the other chain.
-        // For example, if the token on this chain has 18 decimals and the token on the other chain has 8 decimals, the decimal scaling factor should be 10.
-        uint8 decimalScalingFactor;
         uint256 fee;
         uint256 minAmount;
         uint256 maxAmount;
         uint256 maxDeposits;
+        // The decimal scaling factor should be used if the token on this chain has more decimal precision than the token on the other chain.
+        // For example, if the token on this chain has 18 decimals and the token on the other chain has 8 decimals, the decimal scaling factor should be 10.
+        uint256 decimalScalingFactor;
     }
 }

--- a/scripts/deployBridgeAndRegisterNeoToken.ts
+++ b/scripts/deployBridgeAndRegisterNeoToken.ts
@@ -2,8 +2,7 @@ import { ethers } from "hardhat";
 import { deployBridgeContracts } from "./deploy/bridge";
 import { deployTokenContract } from "./deploy/token";
 import { N3_NEO_ADDRESS } from "./utils/addresses";
-import { TokenExecutionType } from "./utils/constants";
-import { registerToken } from "./utils/registration";
+import { registerToken, registerTokenWithScalingFactor } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
 
 async function main() {
@@ -16,7 +15,7 @@ async function main() {
     const token = await deployTokenContract(deployer);
 
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"));
-    await registerToken(bridge, governor, token, TokenExecutionType.NEO, N3_NEO_ADDRESS);
+    await registerTokenWithScalingFactor(bridge, governor, token, N3_NEO_ADDRESS, 18n);
 
     const balanceFunder = await token.balanceOf(await funder.getAddress());
     const balanceBridge = await token.balanceOf(await bridge.getAddress());

--- a/scripts/deployBridgeAndRegisterToken.ts
+++ b/scripts/deployBridgeAndRegisterToken.ts
@@ -2,7 +2,6 @@ import { ethers } from "hardhat";
 import { deployBridgeContracts } from "./deploy/bridge";
 import { deployTokenContract } from "./deploy/token";
 import { getN3TokenAddressFromEnv } from "./utils/addresses";
-import { TokenExecutionType } from "./utils/constants";
 import { registerToken } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
 
@@ -16,7 +15,7 @@ async function main() {
     const token = await deployTokenContract(deployer);
 
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"));
-    await registerToken(bridge, governor, token, TokenExecutionType.ERC20, getN3TokenAddressFromEnv());
+    await registerToken(bridge, governor, token, getN3TokenAddressFromEnv());
 
     const balanceFunder = await token.balanceOf(await funder.getAddress());
     const balanceBridge = await token.balanceOf(await bridge.getAddress());

--- a/scripts/deployTokenAndRegister.ts
+++ b/scripts/deployTokenAndRegister.ts
@@ -1,7 +1,6 @@
 import { ethers } from "hardhat";
 import { deployTokenContract } from "./deploy/token";
 import { getBridgeFromEnv, getN3TokenAddressFromEnv } from "./utils/addresses";
-import { TokenExecutionType } from "./utils/constants";
 import { fundIfLocalNetwork } from "./utils/network";
 import { registerToken } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
@@ -12,7 +11,7 @@ async function main() {
     await fundIfLocalNetwork([deployer.address, governor.address]);
     const bridge = await getBridgeFromEnv(ethers.provider);
     const token = await deployTokenContract(deployer);
-    await registerToken(bridge, governor, token, TokenExecutionType.ERC20, getN3TokenAddressFromEnv());
+    await registerToken(bridge, governor, token, getN3TokenAddressFromEnv());
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"));
 }
 

--- a/scripts/deployTokenAndRegisterNeo.ts
+++ b/scripts/deployTokenAndRegisterNeo.ts
@@ -1,9 +1,8 @@
 import { ethers } from "hardhat";
 import { deployTokenContract } from "./deploy/token";
 import { getBridgeFromEnv, N3_NEO_ADDRESS } from "./utils/addresses";
-import { TokenExecutionType } from "./utils/constants";
 import { fundIfLocalNetwork } from "./utils/network";
-import { registerToken } from "./utils/registration";
+import { registerTokenWithScalingFactor } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
 
 async function main() {
@@ -12,7 +11,7 @@ async function main() {
     await fundIfLocalNetwork([deployer.address, governor.address]);
     const bridge = await getBridgeFromEnv(ethers.provider);
     const token = await deployTokenContract(deployer);
-    await registerToken(bridge, governor, token, TokenExecutionType.NEO, N3_NEO_ADDRESS);
+    await registerTokenWithScalingFactor(bridge, governor, token, N3_NEO_ADDRESS, 18n);
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"));
 }
 

--- a/scripts/registerNeo.ts
+++ b/scripts/registerNeo.ts
@@ -1,8 +1,7 @@
 import { ethers } from "hardhat";
 import { N3_NEO_ADDRESS, getBridgeFromEnv, getNeoXTokenFromEnv } from "./utils/addresses";
-import { TokenExecutionType } from "./utils/constants";
 import { fundIfLocalNetwork } from "./utils/network";
-import { registerToken } from "./utils/registration";
+import { registerTokenWithScalingFactor } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
 
 async function main() {
@@ -11,7 +10,7 @@ async function main() {
     await fundIfLocalNetwork([deployer.address, governor.address]);
     const bridge = await getBridgeFromEnv(ethers.provider);
     const token = await getNeoXTokenFromEnv();
-    await registerToken(bridge, governor, token, TokenExecutionType.NEO, N3_NEO_ADDRESS);
+    await registerTokenWithScalingFactor(bridge, governor, token, N3_NEO_ADDRESS, 18n);
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"));
 }
 

--- a/scripts/registerToken.ts
+++ b/scripts/registerToken.ts
@@ -1,6 +1,6 @@
 import { ethers } from "hardhat";
 import { N3_TOKEN_ADDRESS, getBridgeFromEnv, getNeoXTokenFromEnv } from "./utils/addresses";
-import { TokenExecutionType, MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS } from "./utils/constants";
+import { MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS } from "./utils/constants";
 import { fundIfLocalNetwork } from "./utils/network";
 import { registerToken } from "./utils/registration";
 import { getDeployer, getOwner } from "./utils/wallet";
@@ -11,7 +11,7 @@ async function main() {
     await fundIfLocalNetwork([deployer.address, governor.address]);
     const bridge = await getBridgeFromEnv(ethers.provider);
     const token = await getNeoXTokenFromEnv();
-    await registerToken(bridge, governor, token, TokenExecutionType.ERC20, N3_TOKEN_ADDRESS);
+    await registerToken(bridge, governor, token, N3_TOKEN_ADDRESS);
     await token.connect(deployer).transfer(await bridge.getAddress(), ethers.parseEther("10000"), { maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS });
 }
 

--- a/scripts/utils/constants.ts
+++ b/scripts/utils/constants.ts
@@ -1,10 +1,5 @@
 import { ethers } from "hardhat";
 
-export enum TokenExecutionType {
-    NEO = 0,
-    ERC20 = 1
-}
-
 export const HARDHAT_LOCAL_NETWORK_CHAIN_ID = 1n;
 export const HARDHAT_DEFAULT_PROVIDER_NETWORK_CHAIN_ID = 31337n;
 export const NEOX_TESTNET_CHAIN_ID = 12227332n;

--- a/scripts/utils/registration.ts
+++ b/scripts/utils/registration.ts
@@ -1,21 +1,25 @@
 import { Wallet } from "ethers";
 import { ethers } from "hardhat";
 import { TestToken, TestBridge } from "../../typechain-types/contracts/tests";
-import { TokenExecutionType, MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS } from "./constants";
+import { MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS } from "./constants";
 import { fundIfLocalNetwork } from "./network";
 
-export async function registerToken(bridge: TestBridge, governor: Wallet, token: TestToken, executionType: TokenExecutionType, n3TokenAddress: string) {
+export async function registerToken(bridge: TestBridge, governor: Wallet, token: TestToken, n3TokenAddress: string) {
+    await registerTokenWithScalingFactor(bridge, governor, token, n3TokenAddress, 0n);
+}
+
+export async function registerTokenWithScalingFactor(bridge: TestBridge, governor: Wallet, token: TestToken, n3TokenAddress: string, decimalScalingFactor: bigint) {
     await fundIfLocalNetwork([governor.address]);
     console.log("\n#####################################################################");
     console.log("######################### Token Registration ########################");
     console.log("#####################################################################");
     const tokenConfig = {
         neoN3Token: n3TokenAddress,
+        decimalScalingFactor: decimalScalingFactor,
         fee: ethers.parseEther("0.1"),
         minAmount: ethers.parseEther("1"),
         maxAmount: ethers.parseEther("10000"),
         maxDeposits: 100,
-        executionType: executionType,
     }
 
     const registration = await bridge.connect(governor).registerToken(await token.getAddress(), tokenConfig, { maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS });

--- a/scripts/withdrawToken.ts
+++ b/scripts/withdrawToken.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
 import { deployBridgeContracts } from "./deploy/bridge";
 import { defaultN3TokenAddress, getBridgeFromEnv, getN3DefaultRecipientFromEnv, getNeoXTokenFromEnv } from "./utils/addresses";
-import { MAX_FEE_PER_GAS, TokenExecutionType } from "./utils/constants";
+import { MAX_FEE_PER_GAS } from "./utils/constants";
 import { fundIfLocalNetwork, isLocalNetwork } from "./utils/network";
 import { getDeployer, getOwner } from "./utils/wallet";
 import { deployTokenContract } from "./deploy/token";
@@ -18,7 +18,7 @@ async function main() {
     if (isLocalNetwork(await ethers.provider.getNetwork())) {
         bridge = await deployBridgeContracts();
         token = await deployTokenContract(sender);
-        await registerToken(bridge, governor, token, TokenExecutionType.ERC20, defaultN3TokenAddress());
+        await registerToken(bridge, governor, token, defaultN3TokenAddress());
     } else {
         bridge = await getBridgeFromEnv(ethers.provider);
         token = await getNeoXTokenFromEnv();

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -73,11 +73,11 @@ contract BridgeImplTest is Test, SigUtils {
 
         validConfig = StorageTypes.TokenConfig({
             neoN3Token: neoN3Token,
+            decimalScalingFactor: 18,
             fee: 1,
             minAmount: 100,
             maxAmount: 1000,
-            maxDeposits: 10,
-            executionType: StorageTypes.ExecutionType.NEO
+            maxDeposits: 10
         });
     }
 
@@ -116,11 +116,11 @@ contract BridgeImplTest is Test, SigUtils {
         StorageTypes.TokenConfig memory invalidConfig = StorageTypes
             .TokenConfig({
                 neoN3Token: neoN3Token,
+                decimalScalingFactor: 18,
                 fee: 1,
                 minAmount: 1000,
                 maxAmount: 100,
-                maxDeposits: 10,
-                executionType: StorageTypes.ExecutionType.NEO
+                maxDeposits: 10
             });
         bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
@@ -132,11 +132,11 @@ contract BridgeImplTest is Test, SigUtils {
         StorageTypes.TokenConfig memory invalidConfig = StorageTypes
             .TokenConfig({
                 neoN3Token: neoN3Token,
+                decimalScalingFactor: 18,
                 fee: 0,
                 minAmount: 1,
                 maxAmount: 10000,
-                maxDeposits: 10,
-                executionType: StorageTypes.ExecutionType.NEO
+                maxDeposits: 10
             });
         bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
@@ -148,11 +148,11 @@ contract BridgeImplTest is Test, SigUtils {
         StorageTypes.TokenConfig memory invalidConfig = StorageTypes
             .TokenConfig({
                 neoN3Token: neoN3Token,
+                decimalScalingFactor: 18,
                 fee: 1,
                 minAmount: 0,
                 maxAmount: 100,
-                maxDeposits: 10,
-                executionType: StorageTypes.ExecutionType.NEO
+                maxDeposits: 10
             });
         bridgeProxy.registerToken(neoXToken, invalidConfig);
     }
@@ -164,11 +164,11 @@ contract BridgeImplTest is Test, SigUtils {
         StorageTypes.TokenConfig memory invalidConfig = StorageTypes
             .TokenConfig({
                 neoN3Token: address(0),
+                decimalScalingFactor: 18,
                 fee: 1,
                 minAmount: 100,
                 maxAmount: 1000,
-                maxDeposits: 10,
-                executionType: StorageTypes.ExecutionType.NEO
+                maxDeposits: 10
             });
         bridgeProxy.registerToken(neoXToken, invalidConfig);
     }

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -747,7 +747,7 @@ describe("Bridge Implementation", function () {
 
             await expect(bridgeContract.connect(validator1).pauseBridge()).to.be.revertedWithCustomError(bridgeContract, "NoAuthorization");
             expect(await bridgeContract.bridgePaused()).to.equal(false);
-            
+
             await bridgeContract.connect(governor).pauseBridge();
             expect(await bridgeContract.bridgePaused()).to.equal(true);
             await bridgeContract.connect(governor).unpauseBridge();

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -94,19 +94,19 @@ contract TestFungibleToken is Test, SigUtils {
         neoXTokenB = address(new MockERC20("MockB", "MB"));
         validConfigA = StorageTypes.TokenConfig({
             neoN3Token: neoN3TokenA,
+            decimalScalingFactor: 0,
             fee: 1,
             minAmount: 100,
             maxAmount: 1000,
-            maxDeposits: 2,
-            executionType: StorageTypes.ExecutionType.ERC20
+            maxDeposits: 2
         });
         validConfigB = StorageTypes.TokenConfig({
             neoN3Token: neoN3TokenB,
+            decimalScalingFactor: 18,
             fee: 1,
             minAmount: 100,
             maxAmount: 1000 ether,
-            maxDeposits: 2,
-            executionType: StorageTypes.ExecutionType.NEO
+            maxDeposits: 2
         });
 
         // Fund the test accounts with some ether.
@@ -928,11 +928,15 @@ contract TestFungibleToken is Test, SigUtils {
             ),
             allowance
         );
-        
+
         uint256 fee = bridgeProxy.getTokenConfig(neoXTokenA).fee;
         uint256 transferAmount = 200;
         vm.prank(transferUser0);
-        bridgeProxy.withdrawToken{value: fee}(neoXTokenA, transferUser1, transferAmount);
+        bridgeProxy.withdrawToken{value: fee}(
+            neoXTokenA,
+            transferUser1,
+            transferAmount
+        );
         assertEq(
             MockERC20(neoXTokenA).allowance(
                 transferUser0,
@@ -946,25 +950,24 @@ contract TestFungibleToken is Test, SigUtils {
         assertTrue(bridgeProxy.getWithdrawalsPaused());
 
         vm.expectRevert(abi.encodeWithSignature("WithdrawalsPaused()"));
-        bridgeProxy.withdrawToken(
-            neoXTokenA,
-            transferUser0,
-            transferAmount
-        );
+        bridgeProxy.withdrawToken(neoXTokenA, transferUser0, transferAmount);
     }
 
     // Test case: Deposits should be allowed while withdrawals are paused
     function test_DepositsAreAllowedWhileWithdrawalsPaused() public {
         uint256 initialBridgeBalance = 10000;
         MockERC20(neoXTokenA).mint(address(bridgeProxy), initialBridgeBalance);
-        assertEq(MockERC20(neoXTokenA).balanceOf(address(bridgeProxy)), initialBridgeBalance);
+        assertEq(
+            MockERC20(neoXTokenA).balanceOf(address(bridgeProxy)),
+            initialBridgeBalance
+        );
         vm.prank(governor);
         bridgeProxy.registerToken(neoXTokenA, validConfigA);
         assertFalse(bridgeProxy.getWithdrawalsPaused());
         vm.prank(governor);
         bridgeProxy.pauseWithdrawals();
         assertTrue(bridgeProxy.getWithdrawalsPaused());
-        
+
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](1);
         uint256 depositAmount = 700;
@@ -998,7 +1001,10 @@ contract TestFungibleToken is Test, SigUtils {
             depositData
         );
         // check balance
-        assertEq(MockERC20(neoXTokenA).balanceOf(address(bridgeProxy)), initialBridgeBalance - depositAmount);
+        assertEq(
+            MockERC20(neoXTokenA).balanceOf(address(bridgeProxy)),
+            initialBridgeBalance - depositAmount
+        );
         assertEq(MockERC20(neoXTokenA).balanceOf(transferUser0), depositAmount);
     }
 

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -98,11 +98,11 @@ contract TokenBridgeSyncTest is Test, SigUtils {
 
         neoBridgeConfig = StorageTypes.TokenConfig({
             neoN3Token: neoN3NeoToken,
+            decimalScalingFactor: 18,
             fee: 0.1 ether,
             minAmount: 1,
             maxAmount: 1000 ether,
-            maxDeposits: 2,
-            executionType: StorageTypes.ExecutionType.NEO
+            maxDeposits: 2
         });
 
         // Fund the test accounts with some ether.


### PR DESCRIPTION
Previously the variable `ExecutionType` was used for deciding if the amount used in the hashing computation should be used for the transfer amount or if 18 decimals should be added to it (i.e., for NEO, since it has no decimals on N3, but likely will have 18 decimals on Neo X). This restricted the registration of tokens that have different decimal places on N3 and Neo X (other than the difference being exactly 18) and would have required a new execution type for each decimal difference.

This PR replaces the concept of "execution type" with a decimal scaling factor. That decimal scaling factor defines what number of decimals need to be **added** to the amount used for the hash chain to get the actual transfer amount.

The value needs only be set in token registrations if tokens have different decimals on both chains and it only needs to be set on the chain where the token has more decimals since the amount with less decimals is used for the hash chain computation.

For example, with Neo, the decimal scaling factor will need to be 18 on Neo X (given the Neo token on Neo X has 18 decimals (18 more than on N3)) and the decimal scaling factor on the registered Neo token bridge on N3 should be 0.