### PR TITLE
Move initializer functions to test contracts

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -9,28 +9,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
-    function initialize(
-        address _management,
-        uint256 _fee,
-        uint256 _minAmount,
-        uint256 _maxAmount,
-        uint256 _maxDeposits
-    ) public initializer {
-        __ReentrancyGuard_init();
-        management = IBridgeManagement(_management);
-        gasBridge = StorageTypes.GasBridge({
-            paused: false,
-            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
-            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
-            config: StorageTypes.GasConfig({
-                fee: _fee,
-                minAmount: _minAmount,
-                maxAmount: _maxAmount,
-                maxDeposits: _maxDeposits
-            })
-        });
-    }
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -7,23 +7,6 @@ import "../library/BridgeLib.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
-    function initialize(
-        address _owner,
-        address _relayer,
-        uint256 _validatorThreshold,
-        address[] calldata _validators,
-        address _governor,
-        address _securityGuard,
-        address _funder
-    ) public initializer {
-        __Ownable_init(_owner);
-        _setRelayer(_relayer);
-        _setValidators(_validators, _validatorThreshold);
-        _setGovernor(_governor);
-        _setSecurityGuard(_securityGuard);
-        _setFunder(_funder);
-    }
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();

--- a/contracts/tests/TestBridge.sol
+++ b/contracts/tests/TestBridge.sol
@@ -8,13 +8,7 @@ contract TestBridge is BridgeImpl {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() BridgeImpl() {}
 
-    function initialize(
-        address _management,
-        uint256 _fee,
-        uint256 _minAmount,
-        uint256 _maxAmount,
-        uint256 _maxDeposits
-    ) public initializer {
+    function initialize(address _management) public initializer {
         __ReentrancyGuard_init();
         management = IBridgeManagement(_management);
         gasBridge = StorageTypes.GasBridge({
@@ -22,10 +16,10 @@ contract TestBridge is BridgeImpl {
             depositState: StorageTypes.State({nonce: 0, root: 0x0}),
             withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
             config: StorageTypes.GasConfig({
-                fee: _fee,
-                minAmount: _minAmount,
-                maxAmount: _maxAmount,
-                maxDeposits: _maxDeposits
+                fee: 1e17,
+                minAmount: 1e18,
+                maxAmount: 1e22,
+                maxDeposits: 100
             })
         });
     }

--- a/contracts/tests/TestBridge.sol
+++ b/contracts/tests/TestBridge.sol
@@ -5,6 +5,31 @@ import "../bridge/BridgeImpl.sol";
 import "./interfaces/ITestBridgeManagement.sol";
 
 contract TestBridge is BridgeImpl {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() BridgeImpl() {}
+
+    function initialize(
+        address _management,
+        uint256 _fee,
+        uint256 _minAmount,
+        uint256 _maxAmount,
+        uint256 _maxDeposits
+    ) public initializer {
+        __ReentrancyGuard_init();
+        management = IBridgeManagement(_management);
+        gasBridge = StorageTypes.GasBridge({
+            paused: false,
+            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
+            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
+            config: StorageTypes.GasConfig({
+                fee: _fee,
+                minAmount: _minAmount,
+                maxAmount: _maxAmount,
+                maxDeposits: _maxDeposits
+            })
+        });
+    }
+
     modifier onlyOwner() {
         require(
             msg.sender == ITestBridgeManagement(address(management)).owner(),
@@ -17,6 +42,8 @@ contract TestBridge is BridgeImpl {
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyOwner {}
+
+    // Additional helper functions for testing purposes.
 
     function isRegisteredToken(address neoXToken) public view returns (bool) {
         return _isRegisteredToken(neoXToken);

--- a/contracts/tests/TestBridgeManagement.sol
+++ b/contracts/tests/TestBridgeManagement.sol
@@ -4,6 +4,26 @@ pragma solidity 0.8.25;
 import "../management/BridgeManagementImpl.sol";
 
 contract TestBridgeManagement is BridgeManagementImpl {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() BridgeManagementImpl() {}
+
+    function initialize(
+        address _owner,
+        address _relayer,
+        uint256 _validatorThreshold,
+        address[] calldata _validators,
+        address _governor,
+        address _securityGuard,
+        address _funder
+    ) public initializer {
+        __Ownable_init(_owner);
+        _setRelayer(_relayer);
+        _setValidators(_validators, _validatorThreshold);
+        _setGovernor(_governor);
+        _setSecurityGuard(_securityGuard);
+        _setFunder(_funder);
+    }
+
     // Authorize the contract owner to upgrade the contract for testing purposes.
     function _authorizeUpgrade(
         address newImplementation

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import "../lib/forge-std/src/Test.sol";
-import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
-import "../contracts/bridge/BridgeStorage.sol";
-import "../contracts/management/BridgeManagementImpl.sol";
-import "../contracts/tests/SigUtils.sol";
-import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
+import {BridgeStorage, StorageTypes} from "../contracts/bridge/BridgeStorage.sol";
+import {SigUtils} from "../contracts/tests/SigUtils.sol";
+import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
+import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract BridgeImplTest is Test, SigUtils {
     TestBridge bridgeProxy;
@@ -44,9 +44,9 @@ contract BridgeImplTest is Test, SigUtils {
         opts.unsafeAllow = "constructor";
         // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
         managementProxyAddress = Upgrades.deployUUPSProxy(
-            "BridgeManagementImpl.sol",
+            "TestBridgeManagement.sol",
             abi.encodeCall(
-                BridgeManagementImpl.initialize,
+                TestBridgeManagement.initialize,
                 (
                     owner,
                     relayer,
@@ -64,7 +64,7 @@ contract BridgeImplTest is Test, SigUtils {
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
             abi.encodeCall(
-                BridgeImpl.initialize,
+                TestBridge.initialize,
                 (managementProxyAddress, 1e17, 1e18, 1e22, 100)
             ),
             opts

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -63,10 +63,7 @@ contract BridgeImplTest is Test, SigUtils {
         // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+            abi.encodeCall(TestBridge.initialize, (managementProxyAddress)),
             opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));

--- a/test/BridgeManagement.t.sol
+++ b/test/BridgeManagement.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import "../lib/forge-std/src/Test.sol";
-import "../contracts/management/BridgeManagementImpl.sol";
-import "../contracts/tests/SigUtils.sol";
-import "../contracts/library/BridgeLib.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeLib} from "../contracts/library/BridgeLib.sol";
+import {SigUtils} from "../contracts/tests/SigUtils.sol";
+import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract BridgeManagementImplTest is Test, SigUtils {
-    BridgeManagementImpl managementProxy;
+    TestBridgeManagement managementProxy;
     address managementProxyAddress;
 
     SigUtils sigUtils;
@@ -45,9 +45,9 @@ contract BridgeManagementImplTest is Test, SigUtils {
         opts.unsafeAllow = "constructor";
         // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
         managementProxyAddress = Upgrades.deployUUPSProxy(
-            "BridgeManagementImpl.sol",
+            "TestBridgeManagement.sol",
             abi.encodeCall(
-                BridgeManagementImpl.initialize,
+                TestBridgeManagement.initialize,
                 (
                     owner,
                     relayer,
@@ -60,7 +60,7 @@ contract BridgeManagementImplTest is Test, SigUtils {
             ),
             opts
         );
-        managementProxy = BridgeManagementImpl(payable(managementProxyAddress));
+        managementProxy = TestBridgeManagement(payable(managementProxyAddress));
     }
 
     function testSetOwner() public {

--- a/test/BridgeManagementTest.ts
+++ b/test/BridgeManagementTest.ts
@@ -20,7 +20,7 @@ describe("Bridge Management", function () {
             deployer,
             funder
         ] = await ethers.getSigners();
-        const BridgeManagementFactory = (await ethers.getContractFactory("BridgeManagementImpl"));
+        const BridgeManagementFactory = (await ethers.getContractFactory("TestBridgeManagement"));
         const proxy = await upgrades.deployProxy(BridgeManagementFactory, [
             owner.address,
             relayer.address,
@@ -32,7 +32,7 @@ describe("Bridge Management", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await proxy.waitForDeployment();
 
-        const bridgeManagementImpl = proxy as BridgeManagementImpl;
+        const bridgeManagementImpl = proxy as TestBridgeManagement;
 
         return {
             bridgeManagementImpl,

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -29,7 +29,7 @@ describe("Bridge Implementation", function () {
             funder
         ] = await ethers.getSigners();
 
-        const BridgeManagementFactory = (await ethers.getContractFactory("BridgeManagementImpl"));
+        const BridgeManagementFactory = (await ethers.getContractFactory("TestBridgeManagement"));
         const bridgeManagementProxy = await upgrades.deployProxy(BridgeManagementFactory, [
             managementOwner.address,
             relayer.address,
@@ -40,12 +40,12 @@ describe("Bridge Implementation", function () {
             funder.address
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await bridgeManagementProxy.waitForDeployment();
-        const bridgeManagement = bridgeManagementProxy as BridgeManagementImpl;
+        const bridgeManagement = bridgeManagementProxy as TestBridgeManagement;
 
-        const BridgeContractFactory = await ethers.getContractFactory("BridgeImpl");
+        const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
         const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress(), ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100], { kind: "uups", unsafeAllow: ["constructor"] });
         await bridgeProxy.waitForDeployment();
-        const bridge = bridgeProxy as BridgeImpl;
+        const bridge = bridgeProxy as TestBridge;
 
         // Fund the bridge contract.
         await funder.sendTransaction({ to: bridge, value: ethers.parseEther("80.0") });

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -43,7 +43,7 @@ describe("Bridge Implementation", function () {
         const bridgeManagement = bridgeManagementProxy as TestBridgeManagement;
 
         const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
-        const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress(), ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100], { kind: "uups", unsafeAllow: ["constructor"] });
+        const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress()], { kind: "uups", unsafeAllow: ["constructor"] });
         await bridgeProxy.waitForDeployment();
         const bridge = bridgeProxy as TestBridge;
 

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -82,10 +82,7 @@ contract TestFungibleToken is Test, SigUtils {
         // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+            abi.encodeCall(TestBridge.initialize, (managementProxyAddress)),
             opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
-import "../lib/forge-std/src/Test.sol";
-import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
-import {IERC20Errors} from "../node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
-import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
-import "../contracts/management/BridgeManagementImpl.sol";
-import "../contracts/tests/SigUtils.sol";
-import "../contracts/tests/MockERC20.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
+import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
+import {MockERC20} from "../contracts/tests/MockERC20.sol";
+import {SigUtils} from "../contracts/tests/SigUtils.sol";
+import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
+import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract TestFungibleToken is Test, SigUtils {
     TestBridge bridgeProxy;
@@ -23,7 +23,7 @@ contract TestFungibleToken is Test, SigUtils {
     StorageTypes.TokenConfig validConfigB;
 
     // set _management
-    BridgeManagementImpl bridgeManagementImpl;
+    TestBridgeManagement bridgeManagement;
     SigUtils sigUtils;
     address public owner = 0xBcd4042DE499D14e55001CcbB24a551F3b954096;
     address public funder = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
@@ -62,9 +62,9 @@ contract TestFungibleToken is Test, SigUtils {
         opts.unsafeAllow = "constructor";
         // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
         managementProxyAddress = Upgrades.deployUUPSProxy(
-            "BridgeManagementImpl.sol",
+            "TestBridgeManagement.sol",
             abi.encodeCall(
-                BridgeManagementImpl.initialize,
+                TestBridgeManagement.initialize,
                 (
                     owner,
                     relayer,
@@ -77,13 +77,13 @@ contract TestFungibleToken is Test, SigUtils {
             ),
             opts
         );
-        bridgeManagementImpl = BridgeManagementImpl(managementProxyAddress);
+        bridgeManagement = TestBridgeManagement(managementProxyAddress);
 
         // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
             abi.encodeCall(
-                BridgeImpl.initialize,
+                TestBridge.initialize,
                 (managementProxyAddress, 1e17, 1e18, 1e22, 100)
             ),
             opts
@@ -213,7 +213,7 @@ contract TestFungibleToken is Test, SigUtils {
     function testDepositTokenB() public {
         // Verify the signatures of 6 validators
         vm.prank(owner);
-        bridgeManagementImpl.setValidators(validatorsAddresses, 6);
+        bridgeManagement.setValidators(validatorsAddresses, 6);
 
         MockERC20(neoXTokenB).mint(address(bridgeProxy), 1000 ether);
         vm.prank(governor);
@@ -273,7 +273,7 @@ contract TestFungibleToken is Test, SigUtils {
     function testClaimTokenA() public {
         // Verify the signatures of 7 validators
         vm.prank(owner);
-        bridgeManagementImpl.setValidators(validatorsAddresses, 7);
+        bridgeManagement.setValidators(validatorsAddresses, 7);
         vm.prank(governor);
         bridgeProxy.registerToken(neoXTokenA, validConfigA);
         BridgeLib.DepositData[]

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -88,10 +88,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+            abi.encodeCall(TestBridge.initialize, (managementProxyAddress)),
             opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.25;
 
-import "../lib/forge-std/src/Test.sol";
-import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
-import {IERC20Errors} from "../node_modules/@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
-import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
-import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
-import "../contracts/management/BridgeManagementImpl.sol";
-import "../contracts/tests/SigUtils.sol";
-import "../contracts/tests/MockERC20.sol";
+import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
+import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
+import {MockERC20} from "../contracts/tests/MockERC20.sol";
+import {SigUtils} from "../contracts/tests/SigUtils.sol";
+import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
+import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract TokenBridgeSyncTest is Test, SigUtils {
     TestBridge bridgeProxy;
@@ -23,7 +23,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
     StorageTypes.TokenConfig neoBridgeConfig;
 
     // set _management
-    BridgeManagementImpl bridgeManagementImpl;
+    TestBridgeManagement bridgeManagement;
     SigUtils sigUtils;
     address public owner = 0xBcd4042DE499D14e55001CcbB24a551F3b954096;
     address public funder = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
@@ -68,9 +68,9 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         opts.unsafeAllow = "constructor";
         // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
         managementProxyAddress = Upgrades.deployUUPSProxy(
-            "BridgeManagementImpl.sol",
+            "TestBridgeManagement.sol",
             abi.encodeCall(
-                BridgeManagementImpl.initialize,
+                TestBridgeManagement.initialize,
                 (
                     owner,
                     relayer,
@@ -83,13 +83,13 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             ),
             opts
         );
-        bridgeManagementImpl = BridgeManagementImpl(managementProxyAddress);
+        bridgeManagement = TestBridgeManagement(managementProxyAddress);
 
         // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol",
             abi.encodeCall(
-                BridgeImpl.initialize,
+                TestBridge.initialize,
                 (managementProxyAddress, 1e17, 1e18, 1e22, 100)
             ),
             opts
@@ -204,7 +204,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
 
         // Verify the signatures of 6 validators
         vm.prank(owner);
-        bridgeManagementImpl.setValidators(validatorsAddresses, 6);
+        bridgeManagement.setValidators(validatorsAddresses, 6);
 
         BridgeLib.DepositData[]
             memory depositData = new BridgeLib.DepositData[](2);


### PR DESCRIPTION
The initializer functions are not needed for actual deployment, since the contracts in production are already initialized. I moved the initializer functions to corresponding test contract instances that extend the bridge and management contracts.

If we need to reinitialize, we need a different method with a `reinitializer(newVersion)` modifier and not the `initializer` modifier.