### PR TITLE
Prepare structure for reinitializer logic

### DIFF
--- a/contracts/bridge/BridgeImplV1ToV2.sol
+++ b/contracts/bridge/BridgeImplV1ToV2.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "./BridgeImpl.sol";
+
+contract BridgeImplV1ToV2 is BridgeImpl {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() BridgeImpl() {}
+
+    struct TokenMigrationV1 {
+        address token;
+        uint256 decimalScalingFactor;
+    }
+
+    function reinitialize(
+        TokenMigrationV1[] calldata _tokenBridgeMigrations
+    ) public reinitializer(2) {
+        for (uint256 i = 0; i < _tokenBridgeMigrations.length; i++) {
+            TokenMigrationV1 memory migration = _tokenBridgeMigrations[i];
+            if (!_isRegisteredToken(migration.token))
+                revert("Token not registered");
+            StorageTypes.TokenConfig storage config = tokenBridges[
+                migration.token
+            ].config;
+            config.decimalScalingFactor = migration.decimalScalingFactor;
+        }
+    }
+}

--- a/contracts/bridge/BridgeImplV1ToV2.sol
+++ b/contracts/bridge/BridgeImplV1ToV2.sol
@@ -12,9 +12,15 @@ contract BridgeImplV1ToV2 is BridgeImpl {
         uint256 decimalScalingFactor;
     }
 
-    function reinitialize(
+    function upgradeToV2(
         TokenMigrationV1[] calldata _tokenBridgeMigrations
-    ) public reinitializer(2) {
+    ) external virtual reinitializer(2) onlyAdmin {
+        _upgradeToV2(_tokenBridgeMigrations);
+    }
+
+    function _upgradeToV2(
+        TokenMigrationV1[] calldata _tokenBridgeMigrations
+    ) internal onlyInitializing {
         for (uint256 i = 0; i < _tokenBridgeMigrations.length; i++) {
             TokenMigrationV1 memory migration = _tokenBridgeMigrations[i];
             if (!_isRegisteredToken(migration.token))

--- a/contracts/management/BridgeManagementImplV1ToV2.sol
+++ b/contracts/management/BridgeManagementImplV1ToV2.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "./BridgeManagementImpl.sol";
+
+contract BridgeManagementImplV1ToV2 is BridgeManagementImpl {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() BridgeManagementImpl() {}
+
+    function reinitialize() public reinitializer(2) {
+        // Todo: Implement reinitialization logic
+    }
+}

--- a/contracts/tests/migrations/InitializationLib.sol
+++ b/contracts/tests/migrations/InitializationLib.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+library InitializationLib {
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.Initializable")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant INITIALIZABLE_STORAGE =
+        0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
+
+    function _getInitializableStorageValue()
+        internal
+        pure
+        returns (Initializable.InitializableStorage storage $)
+    {
+        assembly {
+            $.slot := INITIALIZABLE_STORAGE
+        }
+    }
+}

--- a/contracts/tests/migrations/TestBridgeV1ToV2.sol
+++ b/contracts/tests/migrations/TestBridgeV1ToV2.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+import "./InitializationLib.sol";
+import "./../interfaces/ITestBridgeManagement.sol";
+import "../../bridge/BridgeImplV1ToV2.sol";
+
+/// @custom:oz-upgrades-from TestBridge
+contract TestBridgeV1ToV2 is BridgeImplV1ToV2 {
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() BridgeImplV1ToV2() {}
+
+    function upgradeToV2(
+        TokenMigrationV1[] calldata _tokenBridgeMigrations
+    ) external override reinitializer(2) onlyOwner {
+        _upgradeToV2(_tokenBridgeMigrations);
+    }
+
+    modifier onlyOwner() {
+        require(
+            msg.sender == ITestBridgeManagement(address(management)).owner(),
+            "Unauthorized"
+        );
+        _;
+    }
+
+    // Authorize the contract owner to upgrade the contract for testing purposes.
+    function _authorizeUpgrade(
+        address newImplementation
+    ) internal virtual override onlyOwner {}
+
+    // Additional helper functions for testing purposes.
+
+    function isRegisteredToken(address neoXToken) public view returns (bool) {
+        return _isRegisteredToken(neoXToken);
+    }
+
+    function getTokenConfig(
+        address neoXToken
+    ) public view returns (StorageTypes.TokenConfig memory config) {
+        config = _getTokenConfig(neoXToken);
+        return config;
+    }
+
+    function getTokenbridgePaused(
+        address neoXToken
+    ) public view returns (bool) {
+        return tokenBridges[neoXToken].paused;
+    }
+
+    function getNeoN3Token(address _neoXToken) public view returns (address) {
+        return _getNeoN3Token(_neoXToken);
+    }
+
+    function getbridgePaused() public view returns (bool) {
+        return bridgePaused;
+    }
+
+    function getWithdrawalsPaused() public view returns (bool) {
+        return withdrawalsPaused;
+    }
+
+    function getTokenDepositState(
+        address neoXToken
+    ) public view returns (StorageTypes.State memory depositState) {
+        return _getTokenDepositState(neoXToken);
+    }
+
+    function getTokenWithdrawalState(
+        address _neoXToken
+    ) public view returns (StorageTypes.State memory withdrawalState) {
+        return _getTokenWithdrawalState(_neoXToken);
+    }
+
+    function hashTokenBridgeOp(
+        address _neoXToken,
+        address _neoN3Token,
+        uint256 _nonce,
+        address _to,
+        uint256 _amount
+    ) public pure returns (bytes32) {
+        return
+            TokenBridgeLib._hashTokenBridgeOp(
+                _neoN3Token,
+                _neoXToken,
+                _nonce,
+                _to,
+                _amount
+            );
+    }
+
+    function computeTokenRoot(
+        bytes32 _previousRoot,
+        address _neoN3Token,
+        address _neoXToken,
+        BridgeLib.DepositData[] calldata _deposits
+    ) public pure returns (bytes32) {
+        return
+            TokenBridgeLib._computeNewTopRoot(
+                _previousRoot,
+                _neoN3Token,
+                _neoXToken,
+                _deposits
+            );
+    }
+
+    // The following code is just for verifying the initialized state of the contract
+
+    function getCurrentInitializedVersion() external view returns (uint256) {
+        return InitializationLib._getInitializableStorageValue()._initialized;
+    }
+}

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -2,15 +2,18 @@
 pragma solidity 0.8.25;
 
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeMigrations} from "./migrations/BridgeMigrations.sol";
 import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
 import {BridgeStorage, StorageTypes} from "../contracts/bridge/BridgeStorage.sol";
+import {BridgeImplV1ToV2} from "../contracts/bridge/BridgeImplV1ToV2.sol";
+import {TestBridgeV1ToV2} from "../contracts/tests/migrations/TestBridgeV1ToV2.sol";
 import {SigUtils} from "../contracts/tests/SigUtils.sol";
 import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
 import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
 import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract BridgeImplTest is Test, SigUtils {
-    TestBridge bridgeProxy;
+    TestBridgeV1ToV2 bridgeProxy;
     address bridgeProxyAddress;
 
     address neoXToken = address(0x6789);
@@ -60,16 +63,14 @@ contract BridgeImplTest is Test, SigUtils {
             opts
         );
 
-        // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
-        bridgeProxyAddress = Upgrades.deployUUPSProxy(
-            "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+        // Deploy the bridge including upgrade steps to V2.
+        bridgeProxyAddress = BridgeMigrations.deployBridgeV1ToV2(
+            managementProxyAddress,
             opts
         );
-        bridgeProxy = TestBridge(payable(bridgeProxyAddress));
+        bridgeProxy = TestBridgeV1ToV2(payable(bridgeProxyAddress));
+        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         validConfig = StorageTypes.TokenConfig({
             neoN3Token: neoN3Token,

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -43,9 +43,16 @@ describe("Bridge Implementation", function () {
         const bridgeManagement = bridgeManagementProxy as TestBridgeManagement;
 
         const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
-        const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress(), ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100], { kind: "uups", unsafeAllow: ["constructor"] });
-        await bridgeProxy.waitForDeployment();
-        const bridge = bridgeProxy as TestBridge;
+        const bridgeProxyV1 = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress(), ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100], { kind: "uups", unsafeAllow: ["constructor"] });
+        await bridgeProxyV1.waitForDeployment();
+
+        const TestBridgeFactoryV1ToV2 = (await ethers.getContractFactory("TestBridgeV1ToV2")).connect(managementOwner);
+        const tokensToMigrate: TokenMigrationV1[] = [];
+        const bridgeProxyV2 = await upgrades.upgradeProxy(await bridgeProxyV1.getAddress(), TestBridgeFactoryV1ToV2, {
+            call: { fn: "upgradeToV2", args: [tokensToMigrate] },
+            unsafeAllow: ["constructor"]
+        });
+        const bridge = bridgeProxyV2 as TestBridge;
 
         // Fund the bridge contract.
         await funder.sendTransaction({ to: bridge, value: ethers.parseEther("80.0") });

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -2,16 +2,17 @@
 pragma solidity 0.8.25;
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeMigrations} from "./migrations/BridgeMigrations.sol";
 import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
 import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
 import {MockERC20} from "../contracts/tests/MockERC20.sol";
 import {SigUtils} from "../contracts/tests/SigUtils.sol";
-import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
 import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {TestBridgeV1ToV2} from "../contracts/tests/migrations/TestBridgeV1ToV2.sol";
 import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract TestFungibleToken is Test, SigUtils {
-    TestBridge bridgeProxy;
+    TestBridgeV1ToV2 bridgeProxy;
     address managementProxyAddress;
     address bridgeProxyAddress;
 
@@ -79,16 +80,14 @@ contract TestFungibleToken is Test, SigUtils {
         );
         bridgeManagement = TestBridgeManagement(managementProxyAddress);
 
-        // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
-        bridgeProxyAddress = Upgrades.deployUUPSProxy(
-            "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+        // Deploy the bridge including upgrade steps to V2.
+        bridgeProxyAddress = BridgeMigrations.deployBridgeV1ToV2(
+            managementProxyAddress,
             opts
         );
-        bridgeProxy = TestBridge(payable(bridgeProxyAddress));
+        bridgeProxy = TestBridgeV1ToV2(payable(bridgeProxyAddress));
+        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         neoXTokenA = address(new MockERC20("MockA", "MA"));
         neoXTokenB = address(new MockERC20("MockB", "MB"));

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -3,16 +3,17 @@ pragma solidity 0.8.25;
 
 import {IERC20Errors} from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";
 import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {BridgeMigrations} from "./migrations/BridgeMigrations.sol";
 import {BridgeStorage, BridgeLib, GasBridgeLib, StorageTypes, TokenBridgeLib} from "../contracts/bridge/BridgeStorage.sol";
 import {ITokenBridge} from "../contracts/interfaces/ITokenBridge.sol";
 import {MockERC20} from "../contracts/tests/MockERC20.sol";
 import {SigUtils} from "../contracts/tests/SigUtils.sol";
-import {TestBridge, BridgeImpl} from "../contracts/tests/TestBridge.sol";
 import {TestBridgeManagement} from "../contracts/tests/TestBridgeManagement.sol";
+import {TestBridgeV1ToV2} from "../contracts/tests/migrations/TestBridgeV1ToV2.sol";
 import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract TokenBridgeSyncTest is Test, SigUtils {
-    TestBridge bridgeProxy;
+    TestBridgeV1ToV2 bridgeProxy;
     address managementProxyAddress;
     address bridgeProxyAddress;
 
@@ -85,16 +86,14 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         );
         bridgeManagement = TestBridgeManagement(managementProxyAddress);
 
-        // Deploy the bridge implementation behind a UUPS proxy and initialize it with the provided parameters.
-        bridgeProxyAddress = Upgrades.deployUUPSProxy(
-            "TestBridge.sol",
-            abi.encodeCall(
-                TestBridge.initialize,
-                (managementProxyAddress, 1e17, 1e18, 1e22, 100)
-            ),
+        // Deploy the bridge including upgrade steps to V2.
+        bridgeProxyAddress = BridgeMigrations.deployBridgeV1ToV2(
+            managementProxyAddress,
             opts
         );
-        bridgeProxy = TestBridge(payable(bridgeProxyAddress));
+        bridgeProxy = TestBridgeV1ToV2(payable(bridgeProxyAddress));
+        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         neoBridgeConfig = StorageTypes.TokenConfig({
             neoN3Token: neoN3NeoToken,

--- a/test/migrations/BridgeMigrations.sol
+++ b/test/migrations/BridgeMigrations.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Upgrades, Options} from "openzeppelin-foundry-upgrades/Upgrades.sol";
+import {TestBridge, BridgeImpl} from "../../contracts/tests/TestBridge.sol";
+import "../../contracts/tests/interfaces/ITestBridgeManagement.sol";
+import {BridgeImplV1ToV2} from "../../contracts/bridge/BridgeImplV1ToV2.sol";
+
+library BridgeMigrations {
+    function deployBridgeV1ToV2(
+        address _managementProxyAddress,
+        Options memory opts
+    ) internal returns (address) {
+        ITestBridgeManagement management = ITestBridgeManagement(
+            _managementProxyAddress
+        );
+        address owner = management.owner();
+        address bridgeV1 = deployBridgeV1(_managementProxyAddress, opts);
+        migrateBridgeV1ToV2(
+            bridgeV1,
+            owner,
+            new BridgeImplV1ToV2.TokenMigrationV1[](0)
+        );
+        return bridgeV1;
+    }
+
+    function deployBridgeV1ToV2WithTokenMigration(
+        address _managementProxyAddress,
+        Options memory opts,
+        BridgeImplV1ToV2.TokenMigrationV1[] memory tokenMigrationsV1ToV2
+    ) internal returns (address) {
+        address bridgeV1 = deployBridgeV1(_managementProxyAddress, opts);
+        ITestBridgeManagement management = ITestBridgeManagement(
+            _managementProxyAddress
+        );
+        address owner = management.owner();
+        migrateBridgeV1ToV2(bridgeV1, owner, tokenMigrationsV1ToV2);
+        return bridgeV1;
+    }
+
+    function deployBridgeV1(
+        address _managementProxyAddress,
+        Options memory opts
+    ) private returns (address) {
+        return
+            Upgrades.deployUUPSProxy(
+                "TestBridge.sol",
+                abi.encodeCall(
+                    TestBridge.initialize,
+                    (_managementProxyAddress, 1e17, 1e18, 1e22, 100)
+                ),
+                opts
+            );
+    }
+
+    function migrateBridgeV1ToV2(
+        address proxy,
+        address owner,
+        BridgeImplV1ToV2.TokenMigrationV1[] memory tokenMigrationsV1ToV2
+    ) private {
+        bytes memory migrationCall = abi.encodeCall(
+            BridgeImplV1ToV2.upgradeToV2,
+            (tokenMigrationsV1ToV2)
+        );
+        Upgrades.upgradeProxy(
+            proxy,
+            "TestBridgeV1ToV2.sol",
+            migrationCall,
+            owner
+        );
+    }
+}


### PR DESCRIPTION
The added contracts `BridgeImplV1ToV2` and `BridgeManagementImplV1ToV2` are intended to be the ones that should be deployed once we're upgrading the bridge contracts. They extend the corresponding `...Impl` contracts and hold the migration logic.

I split the migration logic from the `...Impl` contracts, so that we can maintain reproducible steps in the tests later.\*

\* In a similar pattern as when I moved the initializer functions to test contracts to mock the native contract "deployment", I intend to add this reinitializer parts to V2 test contracts that we can then just upgrade the proxy in the tests triggering the reinitializer instead of writing a new initializer just for the tests.