### PR TITLE
Merge v2 migration code to single initialize function

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -534,15 +534,4 @@ contract BridgeImpl is BridgeStorage, IBridge, IGasBridge, ITokenBridge {
             emit MaxTokenDepositsChange(_neoXTokens[i], maxDeposits);
         }
     }
-
-    // Migration functionality v.1.0.0 to v.2.0.0
-
-    function upgradeToV2(TokenMigration[] calldata _tokenBridgeMigrations)
-        external
-        virtual
-        reinitializer(2)
-        onlyAdmin
-    {
-        _upgradeToV2(_tokenBridgeMigrations);
-    }
 }

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -323,25 +323,4 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     }
 
     function _authorizeUpgrade(address newImplementation) internal virtual override onlyAdmin {}
-
-    // Migration Logic for v1 to v2
-
-    struct TokenMigration {
-        address token;
-        uint256 decimalScalingFactor;
-    }
-
-    // This functionality should be on the lowest level of the inheritance hierarchy. However, since it needs external inputs, it requires a functionality that is not available in the BridgeStorageV1 contract.
-    function _upgradeToV2(TokenMigration[] calldata _tokenBridgeMigrations) internal onlyInitializing {
-        for (uint256 i = 0; i < _tokenBridgeMigrations.length; i++) {
-            TokenMigration memory migration = _tokenBridgeMigrations[i];
-            if (!_isRegisteredToken(migration.token)) revert("Token not registered");
-            // Add token to registered tokens
-            registeredTokens.push(migration.token);
-
-            // Update the token bridge's config
-            StorageTypes.TokenConfig storage config = tokenBridges[migration.token].config;
-            config.decimalScalingFactor = migration.decimalScalingFactor;
-        }
-    }
 }

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -118,10 +118,4 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
     function getFunder() external view override returns (address) {
         return funder;
     }
-
-    // Migration functionality v.1.0.0 to v.2.0.0
-
-    function upgradeToV2() external virtual reinitializer(2) onlyAdmin {
-        _upgradeToV2();
-    }
 }

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -20,7 +20,7 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
 
     // Slot 102 - in slot 102 the size of the address array is stored. The first value is stored at keccak256(uint256(104)) and the rest are stored in subsequent slots.
     // Deprecated in V2
-    address[] internal _v1_validators;
+    address[] internal _v1_validators; // Todo: The values in this array should be removed when upgrading to version 3.
 
     // Slot 103
     address internal governor;
@@ -33,12 +33,4 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
 
     // Slot 106-107
     EnumerableSet.AddressSet internal validatorSet;
-
-    function _upgradeToV2() internal onlyInitializing {
-        // Set validators in new version
-        uint256 validatorsLength = _v1_validators.length;
-        for (uint256 i = 0; i < validatorsLength; i++) {
-            require(validatorSet.add(_v1_validators[i]), "Validator already added");
-        }
-    }
 }

--- a/contracts/tests/TestBridge.sol
+++ b/contracts/tests/TestBridge.sol
@@ -21,34 +21,6 @@ contract TestBridge is BridgeImpl {
         _;
     }
 
-    function initialize(address _management) public initializer {
-        __ReentrancyGuard_init();
-        management = IBridgeManagement(_management);
-        gasBridge = StorageTypes.GasBridge({
-            paused: false,
-            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
-            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
-            config: StorageTypes.GasConfig({fee: 1e17, minAmount: 1e18, maxAmount: 1e22, maxDeposits: 100})
-        });
-    }
-
-    function upgradeToV2(TokenMigration[] calldata _tokenBridgeMigrations)
-        external
-        override
-        reinitializer(2)
-        onlyOwner
-    {
-        _upgradeToV2(_tokenBridgeMigrations);
-    }
-
-    // Authorize the contract owner to upgrade the contract for testing purposes.
-    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
-
-    // This function can be used for verifying the initialized state of the contract
-    function getCurrentInitializedVersion() external view returns (uint256) {
-        return InitializationLib._getInitializableStorageValue()._initialized;
-    }
-
     // Additional helper functions for testing purposes.
 
     function getTokenConfig(address neoXToken) public view returns (StorageTypes.TokenConfig memory config) {
@@ -109,5 +81,32 @@ contract TestBridge is BridgeImpl {
         returns (bytes32)
     {
         return TokenBridgeLib._computeNewTopRoot(_previousRoot, _neoN3Token, _neoXToken, _deposits);
+    }
+
+    //////////////////////////////
+    // Proxy and Initialization //
+    //////////////////////////////
+
+    // Authorize the contract owner to upgrade the contract for testing purposes.
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
+
+    // This function can be used for verifying the initialized state of the contract
+    function getCurrentInitializedVersion() external view returns (uint256) {
+        return InitializationLib._getInitializableStorageValue()._initialized;
+    }
+
+    // Previous initialization functions used to arrive at the current storage slot layout should be summarized here.
+    // The initialization version should reflect the latest release version of the contract that required a reinitialization.
+
+    // Allow non-admins to call the upgrade function for testing purposes.
+    function initialize(address _management) external reinitializer(2) {
+        __ReentrancyGuard_init();
+        management = IBridgeManagement(_management);
+        gasBridge = StorageTypes.GasBridge({
+            paused: false,
+            depositState: StorageTypes.State({nonce: 0, root: 0x0}),
+            withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
+            config: StorageTypes.GasConfig({fee: 1e17, minAmount: 1e18, maxAmount: 1e22, maxDeposits: 100})
+        });
     }
 }

--- a/contracts/tests/TestBridgeManagement.sol
+++ b/contracts/tests/TestBridgeManagement.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.25;
 
 import {InitializationLib} from "./InitializationLib.sol";
-import {BridgeManagementImpl} from "../management/BridgeManagementImpl.sol";
+import {BridgeManagementImpl, EnumerableSet} from "../management/BridgeManagementImpl.sol";
+
+using EnumerableSet for EnumerableSet.AddressSet;
 
 // This TestBridgeManagement contract contains additional or overridden functions as an extension of the BridgeManagementImpl contract. This includes:
 // - Overridden functions with the onlyAdmin modifier are opened to the testing owner (_authorizeUpgrade and _upgrade functions).
@@ -13,10 +15,22 @@ contract TestBridgeManagement is BridgeManagementImpl {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() BridgeManagementImpl() {}
 
-    // Contract storage setup for testing purposes. This setup should mock the currently deployed contract's storage slot layout.
-    // Previous initialization functions used to arrive at the current storage slot layout should be summarized here.
-    // For example, if a slot allocation was used in version 1 but then removed in version 2's re-initialization, this allocation can just be ignored here since it is not allocated in version 2.
+    //////////////////////////////
+    // Proxy and Initialization //
+    //////////////////////////////
 
+    // Authorize the contract owner to upgrade the contract for testing purposes.
+    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
+
+    // This function can be used for verifying the initialized state of the contract
+    function getCurrentInitializedVersion() external view returns (uint256) {
+        return InitializationLib._getInitializableStorageValue()._initialized;
+    }
+
+    // Previous initialization functions used to arrive at the current storage slot layout should be summarized here.
+    // The initialization version should reflect the latest release version of the contract that required a reinitialization.
+
+    // Allow non-admins to initialize the contract for testing purposes.
     function initialize(
         address _owner,
         address _relayer,
@@ -26,8 +40,8 @@ contract TestBridgeManagement is BridgeManagementImpl {
         address _securityGuard,
         address _funder
     )
-        public
-        reinitializer(1)
+        external
+        reinitializer(2)
     {
         // Set storage slots based on currently deployed contract's storage slot layout
         __Ownable_init(_owner);
@@ -41,21 +55,8 @@ contract TestBridgeManagement is BridgeManagementImpl {
         // Ignore any safety-checks since this is just used for test setup.
         uint256 validatorsLength = _validators.length;
         for (uint256 i = 0; i < validatorsLength; i++) {
-            _v1_validators.push(_validators[i]);
+            require(validatorSet.add(_validators[i]), "Validator already added");
         }
         validatorThreshold = _validatorThreshold;
-    }
-
-    // Authorize the test owner address to upgrade the contract for testing purposes.
-    function upgradeToV2() external override reinitializer(2) onlyOwner {
-        _upgradeToV2();
-    }
-
-    // Authorize the contract owner to upgrade the contract for testing purposes.
-    function _authorizeUpgrade(address newImplementation) internal virtual override onlyOwner {}
-
-    // This function can be used for verifying the initialized state of the contract
-    function getCurrentInitializedVersion() external view returns (uint256) {
-        return InitializationLib._getInitializableStorageValue()._initialized;
     }
 }

--- a/scripts/deploy/bridge.ts
+++ b/scripts/deploy/bridge.ts
@@ -14,8 +14,6 @@ export async function deployBridge(managementAddress: string, deployer: Wallet, 
     const bridgeProxy = await upgrades.deployProxy(BridgeFactory, [managementAddress], { kind: "uups", unsafeAllow: ["constructor"], txOverrides: { maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS } });
     await bridgeProxy.waitForDeployment();
     const bridge = await ethers.getContractAt("TestBridge", await bridgeProxy.getAddress());
-    const upgradeTx = await bridge.connect(owner).upgradeToV2([], { maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_FEE_PER_GAS });
-    await upgradeTx.wait();
 
     console.log("\n# Deployment");
     console.log("Bridge Proxy Address:     ", await bridge.getAddress());

--- a/scripts/deploy/management.ts
+++ b/scripts/deploy/management.ts
@@ -20,8 +20,6 @@ export async function deployBridgeManagement(deployer: Wallet): Promise<TestBrid
     const managementProxy = await upgrades.deployProxy(ManagementFactory, [owner.address, relayer.address, 2, [validator01.address, validator02.address], governor.address, securityGuard.address, funder.address], { kind: "uups", unsafeAllow: ["constructor"], txOverrides: { maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_PRIORITY_FEE_PER_GAS } });
     await managementProxy.waitForDeployment();
     const management = await ethers.getContractAt("TestBridgeManagement", await managementProxy.getAddress());
-    const upgradeTx = await management.connect(owner).upgradeToV2({ maxFeePerGas: MAX_FEE_PER_GAS, maxPriorityFeePerGas: MAX_FEE_PER_GAS });
-    await upgradeTx.wait();
 
     console.log("\n# Deployment");
     console.log("Management Proxy Address: ", await management.getAddress());

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -43,7 +43,7 @@ contract BridgeImplTest is Test, SigUtils {
         // The constructor only contains _disableInitializers() which is safe to bypass.
         Options memory opts;
         opts.unsafeAllow = "constructor";
-        // Deploy the bridge management implementation behind a UUPS proxy and initialize it with the provided parameters.
+        // Deploy the bridge management implementation and make sure it's initialized to the latest implementation.
         managementProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridgeManagement.sol",
             abi.encodeCall(
@@ -53,20 +53,16 @@ contract BridgeImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(payable(managementProxyAddress));
-        vm.prank(owner);
-        managementProxy.upgradeToV2();
-        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        // Validate that the bridge proxy has been successfully deployed and initialized to version 2.
         assertEq(managementProxy.getCurrentInitializedVersion(), 2);
 
-        // Deploy the bridge including upgrade steps to V2.
+        // Deploy the bridge and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV2(new BridgeImpl.TokenMigration[](0));
 
-        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        // Validate that the bridge proxy has been successfully deployed and initialized to version 2.
         assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         validConfig = StorageTypes.TokenConfig({

--- a/test/BridgeManagement.t.sol
+++ b/test/BridgeManagement.t.sol
@@ -44,7 +44,7 @@ contract BridgeManagementImplTest is Test, SigUtils {
         Options memory opts;
         opts.unsafeAllow = "constructor";
 
-        // Deploy the management behind a proxy and upgrade it to the latest implementation.
+        // Deploy the management behind a proxy and make sure it's initialized to the latest implementation.
         managementProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridgeManagement.sol",
             abi.encodeCall(
@@ -54,9 +54,7 @@ contract BridgeManagementImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV2();
-        // Validate that the management proxy has been successfully deployed and upgraded to V2.abi
+        // Validate that the management proxy has been successfully deployed and initialized to version 2.
         assertEq(managementProxy.getCurrentInitializedVersion(), 2);
     }
 

--- a/test/BridgeManagementTest.ts
+++ b/test/BridgeManagementTest.ts
@@ -33,9 +33,6 @@ describe("Bridge Management", function () {
         await proxy.waitForDeployment();
         const bridgeManagementImpl = await ethers.getContractAt("TestBridgeManagement", await proxy.getAddress());
 
-        // Upgrade the bridge management contract to V2
-        await bridgeManagementImpl.connect(owner).upgradeToV2();
-
         return {
             bridgeManagementImpl,
             relayer,
@@ -54,6 +51,11 @@ describe("Bridge Management", function () {
     }
 
     describe("Deployment", function () {
+        it("Should be initialized to the correct version", async function () {
+            const { bridgeManagementImpl } = await loadFixture(deployBridgeFixture);
+            expect(await bridgeManagementImpl.getCurrentInitializedVersion()).to.equal(2);
+        });
+
         it("Should have the right relayer", async function () {
             const { bridgeManagementImpl, relayer } = await loadFixture(deployBridgeFixture);
             expect(await bridgeManagementImpl.getRelayer()).to.equal(relayer.address);

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -41,15 +41,11 @@ describe("Bridge Implementation", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await managementProxy.waitForDeployment();
         const bridgeManagement = await ethers.getContractAt("TestBridgeManagement", await managementProxy.getAddress());
-        // Upgrade the bridge management contract to V2
-        await bridgeManagement.connect(managementOwner).upgradeToV2();
 
         const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
         const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress()], { kind: "uups", unsafeAllow: ["constructor"] });
         await bridgeProxy.waitForDeployment();
         const bridge = await ethers.getContractAt("TestBridge", await bridgeProxy.getAddress());
-        // Upgrade the bridge contract to V2
-        await bridge.connect(managementOwner).upgradeToV2([]);
 
         // Fund the bridge contract.
         await funder.sendTransaction({ to: bridge, value: ethers.parseEther("80.0") });
@@ -72,6 +68,18 @@ describe("Bridge Implementation", function () {
             funder
         }
     }
+
+    describe("Deployment", function () {
+        it("Bridge should be initialized to the correct version", async function () {
+            const { bridgeContract } = await loadFixture(deployBridgeFixture);
+            expect(await bridgeContract.getCurrentInitializedVersion()).to.equal(2);
+        });
+
+        it("Bridge Management should be initialized to the correct version", async function () {
+            const { bridgeManagementContract } = await loadFixture(deployBridgeFixture);
+            expect(await bridgeManagementContract.getCurrentInitializedVersion()).to.equal(2);
+        });
+    });
 
     describe("Parameter setters", function () {
         it("Set withdrawal fee", async function () {

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -69,7 +69,7 @@ contract TestFungibleToken is Test, SigUtils {
         Options memory opts;
         opts.unsafeAllow = "constructor";
 
-        // Deploy the management behind a proxy and upgrade it to the latest implementation.
+        // Deploy the management behind a proxy make sure it's initialized to the latest implementation.
         managementProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridgeManagement.sol",
             abi.encodeCall(
@@ -79,18 +79,16 @@ contract TestFungibleToken is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV2();
-        // Validate that the management proxy has been successfully deployed and upgraded to V2.abi
+        // Validate that the management proxy has been successfully deployed and initialized to version 2.
         assertEq(managementProxy.getCurrentInitializedVersion(), 2);
 
-        // Deploy the bridge including upgrade steps to V2.
+        // Deploy the bridge behind a proxy and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV2(new BridgeImpl.TokenMigration[](0));
+        // Validate that the bridge proxy has been successfully deployed and initialized to version 2.
+        assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         neoXTokenA = address(new MockERC20("MockA", "MA"));
         neoXTokenB = address(new MockERC20("MockB", "MB"));

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -74,7 +74,7 @@ contract TokenBridgeSyncTest is Test, SigUtils {
         Options memory opts;
         opts.unsafeAllow = "constructor";
 
-        // Deploy the management behind a proxy and upgrade it to the latest implementation.
+        // Deploy the management behind a proxy and make sure it's initialized to the latest implementation.
         managementProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridgeManagement.sol",
             abi.encodeCall(
@@ -84,20 +84,16 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV2();
-        // Validate that the management proxy has been successfully deployed and upgraded to V2.abi
+        // Validate that the management proxy has been successfully deployed and initialized to version 2.
         assertEq(managementProxy.getCurrentInitializedVersion(), 2);
 
-        // Deploy the bridge including upgrade steps to V2.
+        // Deploy the bridge and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV2(new BridgeImpl.TokenMigration[](0));
 
-        // Validate that the bridge proxy has been successfully deployed and upgraded to V2.
+        // Validate that the bridge proxy has been successfully deployed and initialized to version 2.
         assertEq(bridgeProxy.getCurrentInitializedVersion(), 2);
 
         neoBridgeConfig = StorageTypes.TokenConfig({


### PR DESCRIPTION
To keep a clean codebase, I merged the upgradeToV2 function to the existing initialize function. The merged function has the modifier `reinitializer(2)` to reflect the latest release version that required a reinitialization (which currently is version `2.0.0` - any upgrade should get a major version bump).