### PR TITLE
Delete deprecated array in management contract

### DIFF
--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -118,4 +118,10 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
     function getFunder() external view override returns (address) {
         return funder;
     }
+
+    // Migration functionality v2 to v3
+
+    function upgradeToV3() external virtual reinitializer(3) onlyAdmin {
+        _upgradeToV3();
+    }
 }

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -19,8 +19,7 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
     uint256 internal validatorThreshold;
 
     // Slot 102 - in slot 102 the size of the address array is stored. The first value is stored at keccak256(uint256(104)) and the rest are stored in subsequent slots.
-    // Deprecated in V2
-    address[] internal _v1_validators; // Todo: The values in this array should be removed when upgrading to version 3.
+    address[] internal _v1_validators; // Deprecated in v2 (deleted in v3 upgrade)
 
     // Slot 103
     address internal governor;
@@ -33,4 +32,10 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
 
     // Slot 106-107
     EnumerableSet.AddressSet internal validatorSet;
+
+    function _upgradeToV3() internal onlyInitializing {
+        // The _v1_validators array was deprecated in v2. However, it was not deleted in the v2 upgrade function.
+        // The slots should not be non-zero if they're no longer used, thus, they are emptied now in this upgrade.
+        delete _v1_validators;
+    }
 }

--- a/contracts/tests/TestBridgeManagement.sol
+++ b/contracts/tests/TestBridgeManagement.sol
@@ -59,4 +59,8 @@ contract TestBridgeManagement is BridgeManagementImpl {
         }
         validatorThreshold = _validatorThreshold;
     }
+
+    function upgradeToV3() external override reinitializer(3) onlyOwner {
+        _upgradeToV3();
+    }
 }

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -53,8 +53,10 @@ contract BridgeImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(payable(managementProxyAddress));
-        // Validate that the bridge proxy has been successfully deployed and initialized to version 2.
-        assertEq(managementProxy.getCurrentInitializedVersion(), 2);
+        vm.prank(owner);
+        managementProxy.upgradeToV3();
+        // Validate that the bridge proxy has been successfully deployed and initialized to version 3.
+        assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 
         // Deploy the bridge and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(

--- a/test/BridgeManagement.t.sol
+++ b/test/BridgeManagement.t.sol
@@ -54,8 +54,10 @@ contract BridgeManagementImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        // Validate that the management proxy has been successfully deployed and initialized to version 2.
-        assertEq(managementProxy.getCurrentInitializedVersion(), 2);
+        vm.prank(owner);
+        managementProxy.upgradeToV3();
+        // Validate that the management proxy has been successfully deployed and initialized to version 3.
+        assertEq(managementProxy.getCurrentInitializedVersion(), 3);
     }
 
     function testSetOwner() public {

--- a/test/BridgeManagementTest.ts
+++ b/test/BridgeManagementTest.ts
@@ -32,6 +32,8 @@ describe("Bridge Management", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await proxy.waitForDeployment();
         const bridgeManagementImpl = await ethers.getContractAt("TestBridgeManagement", await proxy.getAddress());
+        // Upgrade the bridge management contract to V3
+        await bridgeManagementImpl.connect(owner).upgradeToV3();
 
         return {
             bridgeManagementImpl,

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -41,6 +41,8 @@ describe("Bridge Implementation", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await managementProxy.waitForDeployment();
         const bridgeManagement = await ethers.getContractAt("TestBridgeManagement", await managementProxy.getAddress());
+        // Upgrade the bridge management contract to V3
+        await bridgeManagement.connect(managementOwner).upgradeToV3();
 
         const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
         const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress()], { kind: "uups", unsafeAllow: ["constructor"] });

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -79,8 +79,10 @@ contract TestFungibleToken is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        // Validate that the management proxy has been successfully deployed and initialized to version 2.
-        assertEq(managementProxy.getCurrentInitializedVersion(), 2);
+        vm.prank(owner);
+        managementProxy.upgradeToV3();
+        // Validate that the management proxy has been successfully deployed and initialized to version 3.
+        assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 
         // Deploy the bridge behind a proxy and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -84,8 +84,10 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        // Validate that the management proxy has been successfully deployed and initialized to version 2.
-        assertEq(managementProxy.getCurrentInitializedVersion(), 2);
+        vm.prank(owner);
+        managementProxy.upgradeToV3();
+        // Validate that the management proxy has been successfully deployed and initialized to version 3.
+        assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 
         // Deploy the bridge and make sure it's initialized to the latest implementation.
         bridgeProxyAddress = Upgrades.deployUUPSProxy(


### PR DESCRIPTION
The storage entry `_v1_validators` has been remapped to the `EnumerableSet.AddreessSet internal validatorSet;`. However, `_v1_validators` was not deleted during the v1->v2 upgrade. Unused non-empty slots should not remain in storage, thus, this pull request adds a reinitializer for the v3 upgrade to delete this unused storage.