### PR TITLE
Add `nativeBridgeIsSet` function

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -48,6 +48,10 @@ contract BridgeImpl is BridgeStorage, IBridge, INativeBridge, ITokenBridge {
 
     // INativeBridge Implementation
 
+    function nativeBridgeIsSet() external view returns (bool) {
+        return _nativeBridgeIsSet();
+    }
+
     function setNativeBridge(
         uint256 _fee,
         uint256 _minAmount,

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -125,12 +125,12 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     }
 
     modifier onlyIfNativeBridgeSet() {
-        if (nativeBridge.config.maxAmount == 0) revert NativeBridgeNotSet();
+        if (!_nativeBridgeIsSet()) revert NativeBridgeNotSet();
         _;
     }
 
     modifier onlyIfNativeBridgeNotSet() {
-        if (nativeBridge.config.maxAmount != 0) revert NativeBridgeAlreadySet();
+        if (_nativeBridgeIsSet()) revert NativeBridgeAlreadySet();
         _;
     }
 
@@ -184,6 +184,10 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
     }
 
     // Native Coin Bridge functions
+
+    function _nativeBridgeIsSet() internal view returns (bool) {
+        return nativeBridge.config.maxAmount != 0;
+    }
 
     function _setNativeBridge(
         uint256 _fee,

--- a/contracts/interfaces/INativeBridge.sol
+++ b/contracts/interfaces/INativeBridge.sol
@@ -23,6 +23,8 @@ interface INativeBridge {
     event MaxNativeWithdrawalChange(uint256 amount);
     event MaxNativeDepositsChange(uint256 amount);
 
+    function nativeBridgeIsSet() external view returns (bool);
+
     function setNativeBridge(
         uint256 _fee,
         uint256 _minAmount,

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -63,8 +63,11 @@ contract BridgeImplTest is Test, SigUtils {
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
         vm.prank(owner);
         bridgeProxy.upgradeToV3();
+        assertFalse(bridgeProxy.nativeBridgeIsSet());
         vm.prank(governor);
         bridgeProxy.setNativeBridge(1e17, 1e18, 1e22, 100, 18, 8);
+        assertTrue(bridgeProxy.nativeBridgeIsSet());
+
         vm.prank(governor);
         bridgeProxy.unpauseNativeBridge();
 


### PR DESCRIPTION
I want to have this in the contract to replicate what we have in the N3 bridge contract and make this one more concise.