### PR TITLE
Clean up contracts for next version

### DIFF
--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -109,7 +109,7 @@ contract BridgeImpl is BridgeStorage, IBridge, INativeBridge, ITokenBridge {
         nonReentrant
     {
         StorageTypes.State memory state = _getNativeBridgeDepositState();
-        StorageTypes.NativeConfigV3 memory config = _getNativeBridgeConfig();
+        StorageTypes.NativeConfig memory config = _getNativeBridgeConfig();
         uint256 depositLength = _deposits.length;
         if (depositLength == 0) revert InvalidDepositsLength();
         if (depositLength > config.maxDeposits) revert InvalidDepositsLength();
@@ -195,7 +195,7 @@ contract BridgeImpl is BridgeStorage, IBridge, INativeBridge, ITokenBridge {
         whenNativeBridgeNotPaused
     {
         if (_to == address(0)) revert InvalidAddress();
-        StorageTypes.NativeConfigV3 memory config = _getNativeBridgeConfig();
+        StorageTypes.NativeConfig memory config = _getNativeBridgeConfig();
         uint256 fee = config.fee;
         if (msg.value < fee) revert InsufficientFee(fee, msg.value); // Prevents underflow and provides clear feedback
         // Revert if the actual fee is higher than the provided max fee.

--- a/contracts/bridge/BridgeImpl.sol
+++ b/contracts/bridge/BridgeImpl.sol
@@ -576,9 +576,9 @@ contract BridgeImpl is BridgeStorage, IBridge, INativeBridge, ITokenBridge {
         }
     }
 
-    // Migration functionality v2 to v3
-
-    function upgradeToV3() external virtual reinitializer(3) onlyAdmin {
-        _upgradeToV3();
-    }
+    // Migration functionality
+    // commented until a reinitialization is needed
+    // function upgradeToV<version_nr>() external virtual reinitializer(<version_nr>) onlyAdmin {
+    //     _upgradeToV<version_nr>();
+    // }
 }

--- a/contracts/bridge/BridgeStorage.sol
+++ b/contracts/bridge/BridgeStorage.sol
@@ -206,11 +206,11 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
 
         uint256 decimalScalingFactor = 0;
         if (_decimalsHere > _decimalsOnN3) decimalScalingFactor = _decimalsHere - _decimalsOnN3;
-        nativeBridge = StorageTypes.NativeBridgeV3({
+        nativeBridge = StorageTypes.NativeBridge({
             paused: true,
             depositState: StorageTypes.State({nonce: 0, root: 0x0}),
             withdrawalState: StorageTypes.State({nonce: 0, root: 0x0}),
-            config: StorageTypes.NativeConfigV3({
+            config: StorageTypes.NativeConfig({
                 fee: _fee,
                 minAmount: _minAmount,
                 maxAmount: _maxAmount,
@@ -240,7 +240,7 @@ abstract contract BridgeStorage is BridgeStorageV1, UUPSUpgradeable {
         delete claimableNative[_nonce];
     }
 
-    function _getNativeBridgeConfig() internal view returns (StorageTypes.NativeConfigV3 memory config) {
+    function _getNativeBridgeConfig() internal view returns (StorageTypes.NativeConfig memory config) {
         return nativeBridge.config;
     }
 

--- a/contracts/bridge/BridgeStorageV1.sol
+++ b/contracts/bridge/BridgeStorageV1.sol
@@ -38,7 +38,7 @@ abstract contract BridgeStorageV1 is ReentrancyGuardUpgradeable {
     address[] public registeredTokens;
 
     // Slot 115
-    StorageTypes.NativeBridgeV3 public nativeBridge;
+    StorageTypes.NativeBridge public nativeBridge;
 
     // commented until a reinitialization is needed
     // function _upgradeToV<version_nr>() internal onlyInitializing {

--- a/contracts/bridge/BridgeStorageV1.sol
+++ b/contracts/bridge/BridgeStorageV1.sol
@@ -30,9 +30,9 @@ abstract contract BridgeStorageV1 is ReentrancyGuardUpgradeable {
     mapping(address tokenAddress => mapping(uint256 nonce => StorageTypes.Claimable claimable) claimableTokens) public
         tokenClaimables;
 
-    // Deprecated in V3 (slots will be cleared in V3 reinitialization)
+    // Deprecated slots in V3 - deleted in v3 upgrade
     // Slots 105-113 (9 slots)
-    StorageTypes.NativeBridgeV2 public nativeBridgeV2;
+    uint256[9] private _gap1;
 
     // Slot 114
     address[] public registeredTokens;

--- a/contracts/bridge/BridgeStorageV1.sol
+++ b/contracts/bridge/BridgeStorageV1.sol
@@ -40,23 +40,7 @@ abstract contract BridgeStorageV1 is ReentrancyGuardUpgradeable {
     // Slot 115
     StorageTypes.NativeBridgeV3 public nativeBridge;
 
-    function _upgradeToV3() internal onlyInitializing {
-        nativeBridge = StorageTypes.NativeBridgeV3(
-            nativeBridgeV2.paused,
-            nativeBridgeV2.depositState,
-            nativeBridgeV2.withdrawalState,
-            StorageTypes.NativeConfigV3(
-                nativeBridgeV2.config.fee,
-                nativeBridgeV2.config.minAmount,
-                nativeBridgeV2.config.maxAmount,
-                nativeBridgeV2.config.maxDeposits,
-                10
-            )
-        );
-        // Reset all values of the slots used by the deprecated nativeBridgeV2
-        nativeBridgeV2.paused = false;
-        nativeBridgeV2.depositState = StorageTypes.State(0, 0);
-        nativeBridgeV2.withdrawalState = StorageTypes.State(0, 0);
-        nativeBridgeV2.config = StorageTypes.NativeConfigV2(0, 0, 0, 0);
-    }
+    // commented until a reinitialization is needed
+    // function _upgradeToV<version_nr>() internal onlyInitializing {
+    // }
 }

--- a/contracts/library/StorageTypes.sol
+++ b/contracts/library/StorageTypes.sol
@@ -15,13 +15,6 @@ library StorageTypes {
 
     // Native Bridge
 
-    struct NativeBridgeV2 {
-        bool paused;
-        State depositState;
-        State withdrawalState;
-        NativeConfigV2 config;
-    }
-
     struct NativeBridgeV3 {
         bool paused;
         State depositState;
@@ -32,13 +25,6 @@ library StorageTypes {
     struct State {
         uint256 nonce;
         bytes32 root;
-    }
-
-    struct NativeConfigV2 {
-        uint256 fee;
-        uint256 minAmount;
-        uint256 maxAmount;
-        uint256 maxDeposits; // This should be used by the validators to decide for which deposit to sign if there are lots of deposits in a single block on the source chain, e.g., if this value is 50 and on the source chain there's 60 deposits in a single block, the resulting roots of deposit 50 and 60 should be signed and provided to the relayer.
     }
 
     struct NativeConfigV3 {

--- a/contracts/library/StorageTypes.sol
+++ b/contracts/library/StorageTypes.sol
@@ -15,11 +15,11 @@ library StorageTypes {
 
     // Native Bridge
 
-    struct NativeBridgeV3 {
+    struct NativeBridge {
         bool paused;
         State depositState;
         State withdrawalState;
-        NativeConfigV3 config;
+        NativeConfig config;
     }
 
     struct State {
@@ -27,7 +27,7 @@ library StorageTypes {
         bytes32 root;
     }
 
-    struct NativeConfigV3 {
+    struct NativeConfig {
         uint256 fee;
         uint256 minAmount;
         uint256 maxAmount;

--- a/contracts/management/BridgeManagementImpl.sol
+++ b/contracts/management/BridgeManagementImpl.sol
@@ -119,9 +119,9 @@ contract BridgeManagementImpl is BridgeManagementStorage, IBridgeManagement {
         return funder;
     }
 
-    // Migration functionality v2 to v3
-
-    function upgradeToV3() external virtual reinitializer(3) onlyAdmin {
-        _upgradeToV3();
-    }
+    // Migration functionality
+    // commented until a reinitialization is needed
+    // function upgradeToV<version_nr>() external virtual reinitializer(<version_nr>) onlyAdmin {
+    //     _upgradeToV<version_nr>();
+    // }
 }

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -18,8 +18,8 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
     // Slot 101
     uint256 internal validatorThreshold;
 
-    // Slot 102 - in slot 102 the size of the address array is stored. The first value is stored at keccak256(uint256(104)) and the rest are stored in subsequent slots.
-    address[] private _gap1; // deleted in v3 upgrade
+    // Slot 102
+    uint256 private _gap1; // deleted in v3 upgrade
 
     // Slot 103
     address internal governor;

--- a/contracts/management/BridgeManagementStorageV1.sol
+++ b/contracts/management/BridgeManagementStorageV1.sol
@@ -19,7 +19,7 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
     uint256 internal validatorThreshold;
 
     // Slot 102 - in slot 102 the size of the address array is stored. The first value is stored at keccak256(uint256(104)) and the rest are stored in subsequent slots.
-    address[] internal _v1_validators; // Deprecated in v2 (deleted in v3 upgrade)
+    address[] private _gap1; // deleted in v3 upgrade
 
     // Slot 103
     address internal governor;
@@ -33,9 +33,7 @@ abstract contract BridgeManagementStorageV1 is Ownable2StepUpgradeable {
     // Slot 106-107
     EnumerableSet.AddressSet internal validatorSet;
 
-    function _upgradeToV3() internal onlyInitializing {
-        // The _v1_validators array was deprecated in v2. However, it was not deleted in the v2 upgrade function.
-        // The slots should not be non-zero if they're no longer used, thus, they are emptied now in this upgrade.
-        delete _v1_validators;
-    }
+    // commented until a reinitialization is needed
+    // function _upgradeToV<version_nr>() internal onlyInitializing {
+    // }
 }

--- a/contracts/tests/TestBridge.sol
+++ b/contracts/tests/TestBridge.sol
@@ -99,12 +99,13 @@ contract TestBridge is BridgeImpl {
     // The initialization version should reflect the latest release version of the contract that required a reinitialization.
 
     // Allow non-admins to call the upgrade function for testing purposes.
-    function initialize(address _management) external reinitializer(2) {
+    function initialize(address _management) external reinitializer(3) { // reinitializer mocks the current version of the contract
         __ReentrancyGuard_init();
         management = IBridgeManagement(_management);
     }
 
-    function upgradeToV3() external override reinitializer(3) onlyOwner {
-        _upgradeToV3();
-    }
+    // commented until a reinitialization is needed
+    // function upgradeToV<version_nr>() external override reinitializer(<version_nr>) onlyOwner {
+    //     _upgradeToV<version_nr>();
+    // }
 }

--- a/contracts/tests/TestBridgeManagement.sol
+++ b/contracts/tests/TestBridgeManagement.sol
@@ -41,7 +41,7 @@ contract TestBridgeManagement is BridgeManagementImpl {
         address _funder
     )
         external
-        reinitializer(2)
+        reinitializer(3) // mocks the current version of the contract
     {
         // Set storage slots based on currently deployed contract's storage slot layout
         __Ownable_init(_owner);
@@ -51,7 +51,7 @@ contract TestBridgeManagement is BridgeManagementImpl {
         _setSecurityGuard(_securityGuard);
         _setFunder(_funder);
 
-        // This is needed to testing migration, i.e., the reinitializer(2) function.
+        // This is needed to testing migration, i.e., the reinitializer(3) function.
         // Ignore any safety-checks since this is just used for test setup.
         uint256 validatorsLength = _validators.length;
         for (uint256 i = 0; i < validatorsLength; i++) {
@@ -60,7 +60,9 @@ contract TestBridgeManagement is BridgeManagementImpl {
         validatorThreshold = _validatorThreshold;
     }
 
-    function upgradeToV3() external override reinitializer(3) onlyOwner {
-        _upgradeToV3();
-    }
+    // Upgrade function allowing to use the reinitializer as non-admin for testing purposes.
+    // commented until a reinitialization is needed
+    // function upgradeToV<version-nr>() external override reinitializer(<version-nr>) onlyOwner {
+    //     _upgradeToV<version-nr>();
+    // }
 }

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -63,8 +63,8 @@ contract BridgeImplTest is Test, SigUtils {
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV3();
+        // vm.prank(owner);
+        // bridgeProxy.upgradeToV<version_nr>();
         assertFalse(bridgeProxy.nativeBridgeIsSet());
         vm.prank(governor);
         bridgeProxy.setNativeBridge(1e17, 1e18, 1e22, 100, 18, 8);

--- a/test/Bridge.t.sol
+++ b/test/Bridge.t.sol
@@ -53,8 +53,8 @@ contract BridgeImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(payable(managementProxyAddress));
-        vm.prank(owner);
-        managementProxy.upgradeToV3();
+        // vm.prank(owner);
+        // managementProxy.upgradeToV<version_nr>();
         // Validate that the bridge proxy has been successfully deployed and initialized to version 3.
         assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 

--- a/test/BridgeManagement.t.sol
+++ b/test/BridgeManagement.t.sol
@@ -54,8 +54,8 @@ contract BridgeManagementImplTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV3();
+        // vm.prank(owner);
+        // managementProxy.upgradeToV<version_nr>();
         // Validate that the management proxy has been successfully deployed and initialized to version 3.
         assertEq(managementProxy.getCurrentInitializedVersion(), 3);
     }

--- a/test/BridgeManagementTest.ts
+++ b/test/BridgeManagementTest.ts
@@ -32,8 +32,8 @@ describe("Bridge Management", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await proxy.waitForDeployment();
         const bridgeManagementImpl = await ethers.getContractAt("TestBridgeManagement", await proxy.getAddress());
-        // Upgrade the bridge management contract to V3
-        await bridgeManagementImpl.connect(owner).upgradeToV3();
+        // Upgrade the bridge management contract to V<version_nr>
+        // await bridgeManagementImpl.connect(owner).upgradeToV<version_nr>();
 
         return {
             bridgeManagementImpl,
@@ -55,7 +55,7 @@ describe("Bridge Management", function () {
     describe("Deployment", function () {
         it("Should be initialized to the correct version", async function () {
             const { bridgeManagementImpl } = await loadFixture(deployBridgeFixture);
-            expect(await bridgeManagementImpl.getCurrentInitializedVersion()).to.equal(2);
+            expect(await bridgeManagementImpl.getCurrentInitializedVersion()).to.equal(3);
         });
 
         it("Should have the right relayer", async function () {

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -41,8 +41,8 @@ describe("Bridge Implementation", function () {
         ], { kind: "uups", unsafeAllow: ["constructor"] });
         await managementProxy.waitForDeployment();
         const bridgeManagement = await ethers.getContractAt("TestBridgeManagement", await managementProxy.getAddress());
-        // Upgrade the bridge management contract to V3
-        await bridgeManagement.connect(managementOwner).upgradeToV3();
+        // Upgrade the bridge management contract to V<version_nr>
+        // await bridgeManagement.connect(managementOwner).upgradeToV<version_nr>();
 
         const BridgeContractFactory = await ethers.getContractFactory("TestBridge");
         const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress()], { kind: "uups", unsafeAllow: ["constructor"] });
@@ -84,7 +84,7 @@ describe("Bridge Implementation", function () {
 
         it("Bridge Management should be initialized to the correct version", async function () {
             const { bridgeManagementContract } = await loadFixture(deployBridgeFixture);
-            expect(await bridgeManagementContract.getCurrentInitializedVersion()).to.equal(2);
+            expect(await bridgeManagementContract.getCurrentInitializedVersion()).to.equal(3);
         });
     });
 

--- a/test/BridgeTest.ts
+++ b/test/BridgeTest.ts
@@ -48,11 +48,12 @@ describe("Bridge Implementation", function () {
         const bridgeProxy = await upgrades.deployProxy(BridgeContractFactory, [await bridgeManagement.getAddress()], { kind: "uups", unsafeAllow: ["constructor"] });
         await bridgeProxy.waitForDeployment();
         const bridge = await ethers.getContractAt("TestBridge", await bridgeProxy.getAddress());
-        // Upgrade the bridge contract to V3
-        await bridge.connect(managementOwner).upgradeToV3();
-        // Only use setNativeBridge on v3.
+        // Activate the native bridge.
         await bridge.connect(governor).setNativeBridge(ethers.parseEther("0.1"), ethers.parseEther("1"), ethers.parseEther("10000"), 100, 18, 8);
         await bridge.connect(governor).unpauseNativeBridge();
+        // Upgrade the bridge contract to V<version_nr>
+        // commented until a reinitialization is needed
+        // await bridge.connect(managementOwner).upgradeToV<version_nr>();
 
         // Fund the bridge contract.
         await funder.sendTransaction({ to: bridge, value: ethers.parseEther("80.0") });

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -89,8 +89,8 @@ contract TestFungibleToken is Test, SigUtils {
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV3();
+        // vm.prank(owner);
+        // bridgeProxy.upgradeToV<version_nr>();
         vm.prank(governor);
         bridgeProxy.setNativeBridge(1e17, 1e18, 1e22, 100, 18, 8);
         vm.prank(governor);

--- a/test/FungibleToken.t.sol
+++ b/test/FungibleToken.t.sol
@@ -79,8 +79,8 @@ contract TestFungibleToken is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV3();
+        // vm.prank(owner);
+        // managementProxy.upgradeToV<version_nr>();
         // Validate that the management proxy has been successfully deployed and initialized to version 3.
         assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -94,8 +94,8 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             "TestBridge.sol", abi.encodeCall(TestBridge.initialize, (managementProxyAddress)), opts
         );
         bridgeProxy = TestBridge(payable(bridgeProxyAddress));
-        vm.prank(owner);
-        bridgeProxy.upgradeToV3();
+        // vm.prank(owner);
+        // bridgeProxy.upgradeToV<version_nr>();
         vm.prank(governor);
         bridgeProxy.setNativeBridge(1e17, 1e18, 1e22, 100, 18, 8);
         vm.prank(governor);

--- a/test/TokenBridgeSync.t.sol
+++ b/test/TokenBridgeSync.t.sol
@@ -84,8 +84,8 @@ contract TokenBridgeSyncTest is Test, SigUtils {
             opts
         );
         managementProxy = TestBridgeManagement(managementProxyAddress);
-        vm.prank(owner);
-        managementProxy.upgradeToV3();
+        // vm.prank(owner);
+        // managementProxy.upgradeToV<version_nr>();
         // Validate that the management proxy has been successfully deployed and initialized to version 3.
         assertEq(managementProxy.getCurrentInitializedVersion(), 3);
 


### PR DESCRIPTION
Closes #245 

This pull request:
- removes the `reinitializer` logic that was needed for the v2->v3 upgrade. The reinitializer logic is now directly integrated in the initializer logic in the test contracts.
- removes the deprecated v2 native bridge structs (incl. config)
- adds appropriate private placeholder variables for the deleted storage slots of the v2 native bridge struct and the deleted `_v1_validators` array slot (values have all been deleted in v3 upgrade).

> I left the reinitialization code commented to act as a minimal boilerplate, so that it'll be easier to set up new reinitialization code once needed. I've added explanatory comments appropriately.

### Storage Layout Details (just for transparency and certainty)

In the storage layout of `BridgeImpl.sol`, the slots used by `nativeBridgeV2` are now covered by the private `_gap1` variable.
**BridgeImpl storage layout on `develop`:**
![Screenshot 2025-07-07 at 17 44 44](https://github.com/user-attachments/assets/d4892c33-d0f9-499d-bc88-8d74ff3edf3c)
**BridgeImpl storage layout on 36a2cbd:**
![Screenshot 2025-07-07 at 17 45 52](https://github.com/user-attachments/assets/28aa4b11-0ecd-4d36-ae35-d81207a720e1)

In the storage layout of `BridgeManagementImpl.sol`, the slot used by `_v1_validators` is now covered by the private `_gap1` variable.
**BridgeManagementImpl storage layout on `develop`:**
![Screenshot 2025-07-07 at 17 41 18](https://github.com/user-attachments/assets/6291a574-d33f-43d7-ae59-71323d46f58e)
**BridgeManagementImpl storage layout on 36a2cbd:**
![Screenshot 2025-07-07 at 17 43 39](https://github.com/user-attachments/assets/e5f517ac-6918-4f5e-a776-a1b2de6d1b94)