### PR TITLE
Align MessageBridge contracts to N3 counter parts

### DIFF
--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -378,7 +378,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         AMBTypes.MetadataExecutable memory metadata =
             abi.decode(getEvmMessage(nonce).encodedMetadata, (AMBTypes.MetadataExecutable));
         if (metadata.storeResult) getStorage().evmExecutionResults[nonce] = abi.encode(result);
-        emit MessageExecuted(nonce, result);
+        emit Execution(nonce, result);
 
         return result;
     }

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -265,12 +265,12 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     /**
      * @notice Stores messages sent from the Neo N3 blockchain.
-     * @param _depositRoot The root of the deposit tree.
+     * @param _evmRoot The root of the EVM hash chain.
      * @param _signatures The signatures of the validators.
      * @param _messages The messages to be stored.
      */
     function storeMessages(
-        bytes32 _depositRoot,
+        bytes32 _evmRoot,
         BridgeLib.Signature[] calldata _signatures,
         AMBTypes.MessageData[] calldata _messages
     )
@@ -296,17 +296,17 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         }
 
         // Validate that the provided message deposit root is equal to the computed root
-        if (MessageBridgeLib._computeNewTopRoot(state.root, _messages) != _depositRoot) revert InvalidRoot();
+        if (MessageBridgeLib._computeNewTopRoot(state.root, _messages) != _evmRoot) revert InvalidRoot();
 
         // Verify that the provided signatures are valid
-        if (!management().verifyValidatorSignatures(_depositRoot, _signatures)) {
+        if (!management().verifyValidatorSignatures(_evmRoot, _signatures)) {
             revert InvalidValidatorSignatures();
         }
 
         // Update the message bridge deposit state
         getStorage().messageBridgeState.evmState =
-            StorageTypes.State({nonce: _messages[messageLength - 1].nonce, root: _depositRoot});
-        emit MessageDepositRootUpdate(_messages[messageLength - 1].nonce, _depositRoot);
+            StorageTypes.State({nonce: _messages[messageLength - 1].nonce, root: _evmRoot});
+        emit EvmRootUpdate(_messages[messageLength - 1].nonce, _evmRoot);
 
         // Store messages
         for (uint256 i = 0; i < messageLength; i++) {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -75,14 +75,14 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     //0x90b8ec18
     error TransferFailed();
 
-    function pauseMessageBridge() external override onlyGovernorOrSecurityGuard whenMessageBridgeNotPaused {
+    function pause() external override onlyGovernorOrSecurityGuard whenNotPaused {
         getStorage().messageBridgeState.paused = true;
-        emit MessageBridgePause();
+        emit Pause();
     }
 
-    function unpauseMessageBridge() external override onlyGovernor whenMessageBridgePaused {
+    function unpause() external override onlyGovernor whenPaused {
         getStorage().messageBridgeState.paused = false;
-        emit MessageBridgeUnpause();
+        emit Unpause();
     }
 
     function pauseSending() external override onlyGovernorOrSecurityGuard whenSendingNotPaused {
@@ -141,7 +141,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     )
         external
         payable
-        whenMessageBridgeNotPaused
+        whenNotPaused
         whenSendingNotPaused
         returns (uint256 nonce)
     {
@@ -162,7 +162,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     function sendMessage(bytes calldata _message)
         external
         payable
-        whenMessageBridgeNotPaused
+        whenNotPaused
         whenSendingNotPaused
         returns (uint256 nonce)
     {
@@ -182,7 +182,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     function sendResultMessage(uint256 _relatedMessageNonce)
         external
         payable
-        whenMessageBridgeNotPaused
+        whenNotPaused
         whenSendingNotPaused
         returns (uint256 nonce)
     {
@@ -277,7 +277,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         external
         override
         onlyRelayer
-        whenMessageBridgeNotPaused
+        whenNotPaused
         nonReentrant
     {
         // Check parameter validity
@@ -438,12 +438,12 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         _;
     }
 
-    modifier whenMessageBridgeNotPaused() {
+    modifier whenNotPaused() {
         if (messageBridgePaused()) revert MessageBridgePaused();
         _;
     }
 
-    modifier whenMessageBridgePaused() {
+    modifier whenPaused() {
         if (!messageBridgePaused()) revert MessageBridgeNotPaused();
         _;
     }

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -260,7 +260,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         getStorage().messageBridgeState.n3State = StorageTypes.State({nonce: nonce, root: newRoot});
 
         // Emit event with all relevant information
-        emit MessageSent(nonce, from, _encodedMetadata, _message, messageHash, newRoot);
+        emit MessageSend(nonce, from, _encodedMetadata, _message, messageHash, newRoot);
     }
 
     /**

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -401,9 +401,9 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         emit MaxNrMessagesChange(_maxNrMessages);
     }
 
-    function setMessageExecutor(address _executor) external override onlyGovernor {
+    function setExecutionManager(address _executor) external override onlyGovernor {
         getStorage().messageExecutionManager = IExecutionManager(_executor);
-        emit MessageExecutorSet(_executor);
+        emit ExecutionManagerChange(_executor);
     }
 
     function setExecutionWindowSeconds(uint256 windowSeconds) external override onlyGovernor {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -383,10 +383,10 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         return result;
     }
 
-    function setMessageBridgeFee(uint256 _fee) external override onlyGovernor {
+    function setSendingFee(uint256 _fee) external override onlyGovernor {
         if (_fee == 0) revert InvalidFee();
         getStorage().messageBridgeState.config.fee = _fee;
-        emit MessageWithdrawalFeeChange(_fee);
+        emit SendingFeeChange(_fee);
     }
 
     function setMaxMessageSize(uint256 _maxSize) external override onlyGovernor {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -324,7 +324,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         _saveAdditionalState(messageData.nonce, messageData.encodedMetadata);
 
-        emit Store(messageData.nonce, messageData.message);
+        emit Store(messageData.nonce, messageData.encodedMetadata);
     }
 
     function _saveAdditionalState(uint256 nonce, bytes memory encodedMetadata) private {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -324,7 +324,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
 
         _saveAdditionalState(messageData.nonce, messageData.encodedMetadata);
 
-        emit MessageDeposit(messageData.nonce, messageData.message);
+        emit Store(messageData.nonce, messageData.message);
     }
 
     function _saveAdditionalState(uint256 nonce, bytes memory encodedMetadata) private {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -40,8 +40,6 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     error MessageNotFound(uint256 nonce);
     //0x25ecb492
     error ResultNotFound(uint256 nonce);
-    //0x774249f8
-    error MessageBridgeNotSet();
     //0xa4c897b0
     error MessageBridgePaused();
     //0xfa5fc19e
@@ -54,10 +52,6 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
     error ExecutingPaused();
     //0x61654835
     error ExecutingNotPaused();
-    //0x018e5d6a
-    error InvalidMessageSize();
-    //0x000bf7e9
-    error MessageRootMismatch();
     //0xd221f922
     error ExecutionManagerNotSet();
     //0x2ad81d67

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -12,7 +12,7 @@ interface IMessageBridge {
     event SendingUnpause();
     event ExecutingPause();
     event ExecutingUnpause();
-    event MessageDeposit(uint256 indexed nonce, bytes message);
+    event Store(uint256 indexed nonce, bytes message);
     event EvmRootUpdate(uint256 indexed nonce, bytes32 evmRoot);
     event MessageWithdrawalFeeChange(uint256 fee);
     event MaxMessageSizeChange(uint256 maxSize);

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -18,7 +18,7 @@ interface IMessageBridge {
     event MaxMessageSizeChange(uint256 maxSize);
     event MaxNrMessagesChange(uint256 maxDeposits);
     event MessageExecutionWindowChange(uint256 windowSeconds);
-    event MessageExecutorSet(address indexed executor);
+    event ExecutionManagerChange(address indexed executor);
     event MessageExecuted(uint256 indexed nonce, AMBTypes.Result result);
     event MessageSend(
         uint256 indexed nonce,
@@ -61,6 +61,6 @@ interface IMessageBridge {
     function setSendingFee(uint256 fee) external;
     function setMaxMessageSize(uint256 maxSize) external;
     function setMaxNrMessages(uint256 maxNrMessages) external;
-    function setMessageExecutor(address executor) external;
+    function setExecutionManager(address executor) external;
     function setExecutionWindowSeconds(uint256 windowSeconds) external;
 }

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -19,7 +19,7 @@ interface IMessageBridge {
     event MaxNrMessagesChange(uint256 maxDeposits);
     event MessageExecutionWindowChange(uint256 windowSeconds);
     event ExecutionManagerChange(address indexed executor);
-    event MessageExecuted(uint256 indexed nonce, AMBTypes.Result result);
+    event Execution(uint256 indexed nonce, AMBTypes.Result result);
     event MessageSend(
         uint256 indexed nonce,
         address indexed sender,

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -12,7 +12,7 @@ interface IMessageBridge {
     event SendingUnpause();
     event ExecutingPause();
     event ExecutingUnpause();
-    event Store(uint256 indexed nonce, bytes message);
+    event Store(uint256 indexed nonce, bytes metadata);
     event EvmRootUpdate(uint256 indexed nonce, bytes32 evmRoot);
     event SendingFeeChange(uint256 fee);
     event MaxMessageSizeChange(uint256 maxSize);

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -14,7 +14,7 @@ interface IMessageBridge {
     event ExecutingUnpause();
     event Store(uint256 indexed nonce, bytes message);
     event EvmRootUpdate(uint256 indexed nonce, bytes32 evmRoot);
-    event MessageWithdrawalFeeChange(uint256 fee);
+    event SendingFeeChange(uint256 fee);
     event MaxMessageSizeChange(uint256 maxSize);
     event MaxNrMessagesChange(uint256 maxDeposits);
     event MessageExecutionWindowChange(uint256 windowSeconds);
@@ -58,7 +58,7 @@ interface IMessageBridge {
         external;
 
     function executeMessage(uint256 nonce) external payable returns (AMBTypes.Result memory);
-    function setMessageBridgeFee(uint256 fee) external;
+    function setSendingFee(uint256 fee) external;
     function setMaxMessageSize(uint256 maxSize) external;
     function setMaxNrMessages(uint256 maxNrMessages) external;
     function setMessageExecutor(address executor) external;

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -6,8 +6,8 @@ import {BridgeLib} from "../../library/BridgeLib.sol";
 import {AMBStorage} from "../AMBStorage.sol";
 
 interface IMessageBridge {
-    event MessageBridgePause();
-    event MessageBridgeUnpause();
+    event Pause();
+    event Unpause();
     event SendingPause();
     event SendingUnpause();
     event ExecutingPause();
@@ -29,8 +29,8 @@ interface IMessageBridge {
         bytes32 newRoot
     );
 
-    function pauseMessageBridge() external;
-    function unpauseMessageBridge() external;
+    function pause() external;
+    function unpause() external;
     function pauseSending() external;
     function unpauseSending() external;
     function pauseExecuting() external;

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -13,7 +13,7 @@ interface IMessageBridge {
     event ExecutingPause();
     event ExecutingUnpause();
     event MessageDeposit(uint256 indexed nonce, bytes message);
-    event MessageDepositRootUpdate(uint256 indexed nonce, bytes32 depositRoot);
+    event EvmRootUpdate(uint256 indexed nonce, bytes32 evmRoot);
     event MessageWithdrawalFeeChange(uint256 fee);
     event MaxMessageSizeChange(uint256 maxSize);
     event MaxNrMessagesChange(uint256 maxDeposits);
@@ -51,7 +51,7 @@ interface IMessageBridge {
     function getResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
     function getN3Result(uint256 relatedMessageNonce) external view returns (bytes memory);
     function storeMessages(
-        bytes32 depositRoot,
+        bytes32 evmRoot,
         BridgeLib.Signature[] calldata signatures,
         AMBTypes.MessageData[] calldata messages
     )

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -20,13 +20,13 @@ interface IMessageBridge {
     event MessageExecutionWindowChange(uint256 windowSeconds);
     event MessageExecutorSet(address indexed executor);
     event MessageExecuted(uint256 indexed nonce, AMBTypes.Result result);
-    event MessageSent(
+    event MessageSend(
         uint256 indexed nonce,
         address indexed sender,
         bytes encodedMetadata,
         bytes message,
         bytes32 messageHash,
-        bytes32 newRoot
+        bytes32 newEvmRoot
     );
 
     function pause() external;

--- a/contracts/tests/TestMessageBridge.sol
+++ b/contracts/tests/TestMessageBridge.sol
@@ -73,6 +73,6 @@ contract TestMessageBridge is MessageBridge {
                 AMBStorage.ExecutableState({executed: false, expirationTimestamp: block.timestamp + window});
         }
 
-        emit MessageDeposit(messageData.nonce, messageData.message);
+        emit Store(messageData.nonce, messageData.message);
     }
 }

--- a/contracts/tests/TestMessageBridge.sol
+++ b/contracts/tests/TestMessageBridge.sol
@@ -73,6 +73,6 @@ contract TestMessageBridge is MessageBridge {
                 AMBStorage.ExecutableState({executed: false, expirationTimestamp: block.timestamp + window});
         }
 
-        emit Store(messageData.nonce, messageData.message);
+        emit Store(messageData.nonce, messageData.encodedMetadata);
     }
 }

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -279,9 +279,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(testContract));
         emit TestContract.TestEvent(1, address(executionManager));
 
-        // Expect the MessageExecuted event to be emitted with correct parameters
+        // Expect the Execution event to be emitted with correct parameters
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(nonce, AMBTypes.Result({success: true, returnData: abi.encode(1)}));
+        emit IMessageBridge.Execution(nonce, AMBTypes.Result({success: true, returnData: abi.encode(1)}));
 
         // Execute the message
         AMBTypes.Result memory result = messageBridgeProxy.executeMessage(nonce);
@@ -324,9 +324,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(testContract));
         emit TestContract.PaymentReceived(paymentAmount, address(executionManager));
 
-        // Expect the MessageExecuted event to be emitted with correct parameters
+        // Expect the Execution event to be emitted with correct parameters
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(nonce, AMBTypes.Result({success: true, returnData: abi.encode(true)}));
+        emit IMessageBridge.Execution(nonce, AMBTypes.Result({success: true, returnData: abi.encode(true)}));
 
         // Execute the message
         AMBTypes.Result memory result = messageBridgeProxy.executeMessage{value: paymentAmount}(nonce);
@@ -370,9 +370,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory expectedErrorData =
             abi.encodeWithSelector(TestContract.ValueMismatch.selector, declaredAmount, actualAmount);
 
-        // Expect the MessageExecuted event to be emitted with failure result
+        // Expect the Execution event to be emitted with failure result
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(nonce, AMBTypes.Result({success: false, returnData: expectedErrorData}));
+        emit IMessageBridge.Execution(nonce, AMBTypes.Result({success: false, returnData: expectedErrorData}));
 
         // Execute the message - this should fail but not revert the transaction
         AMBTypes.Result memory result = messageBridgeProxy.executeMessage{value: actualAmount}(nonce);
@@ -431,9 +431,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(testContract));
         emit TestContract.DirectEthReceived(address(executionManager));
 
-        // Expect the MessageExecuted event to be emitted with success result
+        // Expect the Execution event to be emitted with success result
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(nonce, AMBTypes.Result({success: true, returnData: ""}));
+        emit IMessageBridge.Execution(nonce, AMBTypes.Result({success: true, returnData: ""}));
 
         // Execute the message
         AMBTypes.Result memory result = messageBridgeProxy.executeMessage{value: 1 ether}(nonce);
@@ -469,9 +469,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(testContract));
         emit TestContract.FallbackCalled(address(executionManager), 1 ether, addressBytes);
 
-        // Expect the MessageExecuted event to be emitted with success result
+        // Expect the Execution event to be emitted with success result
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(nonce, AMBTypes.Result({success: true, returnData: ""}));
+        emit IMessageBridge.Execution(nonce, AMBTypes.Result({success: true, returnData: ""}));
 
         // Execute the message
         AMBTypes.Result memory result = messageBridgeProxy.executeMessage{value: 1 ether}(nonce);

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -94,7 +94,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
     function test_MessageBridgePauseUnpause() public {
         // Test pausing
         vm.prank(governor);
-        messageBridgeProxy.pauseMessageBridge();
+        messageBridgeProxy.pause();
 
         // Try to deposit a message while paused (should revert)
         AMBTypes.MessageData[] memory messages = new AMBTypes.MessageData[](1);
@@ -122,7 +122,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Unpause and try again
         vm.prank(governor);
-        messageBridgeProxy.unpauseMessageBridge();
+        messageBridgeProxy.unpause();
 
         // Now it should work (not reverting)
         vm.prank(relayer);
@@ -1395,7 +1395,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Pause the message bridge
         vm.prank(governor);
-        messageBridgeProxy.pauseMessageBridge();
+        messageBridgeProxy.pause();
 
         // Expect revert due to message bridge being paused
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.MessageBridgePaused.selector));
@@ -1618,7 +1618,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Pause the message bridge
         vm.prank(governor);
-        messageBridgeProxy.pauseMessageBridge();
+        messageBridgeProxy.pause();
 
         // Try to send result message while paused
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.MessageBridgePaused.selector));

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -1309,7 +1309,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Set up event expectations
         vm.expectEmit(true, true, true, true);
-        emit IMessageBridge.MessageSent(
+        emit IMessageBridge.MessageSend(
             expectedNonce, // nonce
             address(this), // sender
             encodedMetadata, // encodedMetadata
@@ -1537,9 +1537,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes32 expectedMessageHash = MessageBridgeLib._hashMessageBridgeOp(expectedNonce, expectedMetadata, resultData);
         bytes32 expectedRoot = BridgeLib._computeNewRoot(initialRoot, expectedMessageHash);
 
-        // Expect the MessageSent event
+        // Expect the MessageSend event
         vm.expectEmit(true, true, true, true);
-        emit IMessageBridge.MessageSent(
+        emit IMessageBridge.MessageSend(
             expectedNonce, address(this), expectedMetadata, resultData, expectedMessageHash, expectedRoot
         );
 

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -171,7 +171,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(testContract));
         emit TestContract.TestEvent(1, address(executionManager));
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageExecuted(1, AMBTypes.Result({success: true, returnData: abi.encode(300)}));
+        emit IMessageBridge.Execution(1, AMBTypes.Result({success: true, returnData: abi.encode(300)}));
         messageBridgeProxy.executeMessage(1);
 
         assertEq(testContract.counter(), 1, "Counter should be incremented to 1 after execution");

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -161,7 +161,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDepositRootUpdate(1, newEvmRoot);
+        emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.MessageDeposit(1, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
@@ -237,7 +237,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDepositRootUpdate(2, newEvmRoot);
+        emit IMessageBridge.EvmRootUpdate(2, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.MessageDeposit(2, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
@@ -309,7 +309,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDepositRootUpdate(1, newEvmRoot);
+        emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.MessageDeposit(1, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -155,7 +155,8 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         private
     {
         AMBTypes.MessageData[] memory messages = new AMBTypes.MessageData[](1);
-        messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: abi.encode(metadata)});
+        bytes memory encodedMetadata = abi.encode(metadata);
+        messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: encodedMetadata});
 
         BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
 
@@ -163,7 +164,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.Store(1, message);
+        emit IMessageBridge.Store(1, encodedMetadata);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
     }
 
@@ -231,7 +232,8 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         );
 
         AMBTypes.MessageData[] memory messages = new AMBTypes.MessageData[](1);
-        messages[0] = AMBTypes.MessageData({nonce: 2, message: message, encodedMetadata: abi.encode(metadata)});
+        bytes memory encodedMetadata = abi.encode(metadata);
+        messages[0] = AMBTypes.MessageData({nonce: 2, message: message, encodedMetadata: encodedMetadata});
 
         BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
 
@@ -239,7 +241,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(2, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.Store(2, message);
+        emit IMessageBridge.Store(2, encodedMetadata);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
 
         vm.expectRevert(
@@ -303,7 +305,8 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         );
 
         AMBTypes.MessageData[] memory messages = new AMBTypes.MessageData[](1);
-        messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: abi.encode(metadata)});
+        bytes memory encodedMetadata = abi.encode(metadata);
+        messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: encodedMetadata});
 
         BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
 
@@ -311,7 +314,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.Store(1, message);
+        emit IMessageBridge.Store(1, encodedMetadata);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
 
         vm.expectRevert(

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -163,7 +163,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDeposit(1, message);
+        emit IMessageBridge.Store(1, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
     }
 
@@ -239,7 +239,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(2, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDeposit(2, message);
+        emit IMessageBridge.Store(2, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
 
         vm.expectRevert(
@@ -311,7 +311,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.MessageDeposit(1, message);
+        emit IMessageBridge.Store(1, message);
         messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
 
         vm.expectRevert(

--- a/test/MessageBridgeTestHelper.sol
+++ b/test/MessageBridgeTestHelper.sol
@@ -99,7 +99,7 @@ abstract contract MessageBridgeTestHelper is Test, SigUtils {
 
         // Unpause the message bridge
         vm.prank(governor);
-        messageBridgeProxy.unpauseMessageBridge();
+        messageBridgeProxy.unpause();
     }
 
     // Helper function to store a single message with generated signatures

--- a/test/MessageBridgeTestHelper.sol
+++ b/test/MessageBridgeTestHelper.sol
@@ -93,9 +93,9 @@ abstract contract MessageBridgeTestHelper is Test, SigUtils {
         // Deploy and set up the Message Executor
         executionManager = new ExecutionManager(messageBridgeProxyAddress);
 
-        // Set the message executor in the bridge
+        // Set the execution manager in the bridge
         vm.prank(governor);
-        messageBridgeProxy.setMessageExecutor(address(executionManager));
+        messageBridgeProxy.setExecutionManager(address(executionManager));
 
         // Unpause the message bridge
         vm.prank(governor);


### PR DESCRIPTION
This pull request aligns some things to the N3 MessageBridge contract. This pull request includes one logical change:

1. The `Store` event (formerly `MessageDeposit`) now holds the metadata of the stored message instead of the message itself.

Additionally, the following has been renamed (only renamed, no logical changes):
| Type | Old | New |
|-|-|-|
| func | `pauseMessageBridge()` | `pause()` |
| func | `unpauseMessageBridge()` | `unpause()` |
| func | `setMessageBridgeFee()` | `setSendingFee()`|
| func | `setMessageExecutor()` | `setExecutionManager()` |
| event | `MessageBridgePause` | `Pause` |
| event | `MessageBridgeUnpause` | `Unpause` |
| event | `MessageDeposit` | `Store` |
| event | `MessageDepositRootUpdate` | `EvmRootUpdate` |
| event | `MessageWithdrawalFeeChange` | `SendingFeeChange` |
| event | `MessageExecutorSet` | `ExecutionManagerChange` |
| event | `MessageExecuted` | `Execution` |
| event | `MessageSent` | `MessageSend` |
| modifier | `whenMessageBridgePaused` | `whenPaused` |
| modifier | `whenMessageBridgeNotPaused` | `whenNotPaused` |

Finally, some unused errors have been removed:
- `MessageBridgeNotSet`
- `InvalidMessageSize`
- `MessageRootMismatch`