### PR TITLE
Using more precise Terms for States

### DIFF
--- a/contracts/messageBridge/AMBStorage.sol
+++ b/contracts/messageBridge/AMBStorage.sol
@@ -25,8 +25,8 @@ abstract contract AMBStorage {
         bool paused;
         bool sendingPaused;
         bool executingPaused;
-        StorageTypes.State evmState;
-        StorageTypes.State n3State;
+        StorageTypes.State neoToEvmState;
+        StorageTypes.State evmToNeoState;
         MessageConfig config;
     }
 
@@ -80,12 +80,12 @@ abstract contract AMBStorage {
     }
 
     // Message Bridge state getters
-    function evmState() public view returns (StorageTypes.State memory) {
-        return getStorage().messageBridgeState.evmState;
+    function neoToEvmState() public view returns (StorageTypes.State memory) {
+        return getStorage().messageBridgeState.neoToEvmState;
     }
 
-    function n3State() public view returns (StorageTypes.State memory) {
-        return getStorage().messageBridgeState.n3State;
+    function evmToNeoState() public view returns (StorageTypes.State memory) {
+        return getStorage().messageBridgeState.evmToNeoState;
     }
 
     // Public config getters (also used internally)

--- a/contracts/messageBridge/AMBStorage.sol
+++ b/contracts/messageBridge/AMBStorage.sol
@@ -75,7 +75,7 @@ abstract contract AMBStorage {
         return getStorage().evmExecutableStates[nonce];
     }
 
-    function getN3ResultNonce(uint256 relatedMessageNonce) public view returns (uint256) {
+    function getNeoExecutionResultNonce(uint256 relatedMessageNonce) public view returns (uint256) {
         return getStorage().executableNonceToN3ResultNonce[relatedMessageNonce];
     }
 

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -225,8 +225,8 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
      * @param relatedMessageNonce The nonce of the related message that was executed.
      * @return result The raw result message bytes.
      */
-    function getN3Result(uint256 relatedMessageNonce) external view returns (bytes memory) {
-        uint256 resultNonce = getN3ResultNonce(relatedMessageNonce);
+    function getNeoExecutionResult(uint256 relatedMessageNonce) external view returns (bytes memory) {
+        uint256 resultNonce = getNeoExecutionResultNonce(relatedMessageNonce);
         if (resultNonce == 0) return new bytes(0); // No result message was sent to N3 so we return empty bytes
         return getEvmMessage(resultNonce).rawMessage;
     }

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -247,7 +247,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         _captureFeeAndRefundExcessToEOA(from, msg.value, sendingFee());
 
         // Compute the new root and update the message state
-        StorageTypes.State memory state = n3State();
+        StorageTypes.State memory state = evmToNeoState();
         nonce = state.nonce + 1;
 
         // Create message hash
@@ -257,7 +257,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         bytes32 newRoot = BridgeLib._computeNewRoot(state.root, messageHash);
 
         // Update the state
-        getStorage().messageBridgeState.n3State = StorageTypes.State({nonce: nonce, root: newRoot});
+        getStorage().messageBridgeState.evmToNeoState = StorageTypes.State({nonce: nonce, root: newRoot});
 
         // Emit event with all relevant information
         emit MessageSend(nonce, from, _encodedMetadata, _message, messageHash, newRoot);
@@ -265,12 +265,12 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     /**
      * @notice Stores messages sent from the Neo N3 blockchain.
-     * @param _evmRoot The root of the EVM hash chain.
+     * @param _neoToEvmRoot The root of the the Neo to EVM hash chain.
      * @param _signatures The signatures of the validators.
      * @param _messages The messages to be stored.
      */
     function storeMessages(
-        bytes32 _evmRoot,
+        bytes32 _neoToEvmRoot,
         BridgeLib.Signature[] calldata _signatures,
         AMBTypes.MessageData[] calldata _messages
     )
@@ -284,7 +284,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         uint256 messageLength = _messages.length;
         if (messageLength == 0) revert NoMessages();
 
-        StorageTypes.State memory state = evmState();
+        StorageTypes.State memory state = neoToEvmState();
 
         if (messageLength > maxNrMessages()) revert TooManyMessages();
 
@@ -296,17 +296,17 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         }
 
         // Validate that the provided message deposit root is equal to the computed root
-        if (MessageBridgeLib._computeNewTopRoot(state.root, _messages) != _evmRoot) revert InvalidRoot();
+        if (MessageBridgeLib._computeNewTopRoot(state.root, _messages) != _neoToEvmRoot) revert InvalidRoot();
 
         // Verify that the provided signatures are valid
-        if (!management().verifyValidatorSignatures(_evmRoot, _signatures)) {
+        if (!management().verifyValidatorSignatures(_neoToEvmRoot, _signatures)) {
             revert InvalidValidatorSignatures();
         }
 
         // Update the message bridge deposit state
-        getStorage().messageBridgeState.evmState =
-            StorageTypes.State({nonce: _messages[messageLength - 1].nonce, root: _evmRoot});
-        emit EvmRootUpdate(_messages[messageLength - 1].nonce, _evmRoot);
+        getStorage().messageBridgeState.neoToEvmState =
+            StorageTypes.State({nonce: _messages[messageLength - 1].nonce, root: _neoToEvmRoot});
+        emit NeoToEvmRootUpdate(_messages[messageLength - 1].nonce, _neoToEvmRoot);
 
         // Store messages
         for (uint256 i = 0; i < messageLength; i++) {

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -265,7 +265,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
 
     /**
      * @notice Stores messages sent from the Neo N3 blockchain.
-     * @param _neoToEvmRoot The root of the the Neo to EVM hash chain.
+     * @param _neoToEvmRoot The root of the Neo to EVM hash chain.
      * @param _signatures The signatures of the validators.
      * @param _messages The messages to be stored.
      */

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -13,7 +13,7 @@ interface IMessageBridge {
     event ExecutingPause();
     event ExecutingUnpause();
     event Store(uint256 indexed nonce, bytes metadata);
-    event EvmRootUpdate(uint256 indexed nonce, bytes32 evmRoot);
+    event NeoToEvmRootUpdate(uint256 indexed nonce, bytes32 neoToEvmRoot);
     event SendingFeeChange(uint256 fee);
     event MaxMessageSizeChange(uint256 maxSize);
     event MaxNrMessagesChange(uint256 maxDeposits);
@@ -26,7 +26,7 @@ interface IMessageBridge {
         bytes encodedMetadata,
         bytes message,
         bytes32 messageHash,
-        bytes32 newEvmRoot
+        bytes32 newEvmToNeoRoot
     );
 
     function pause() external;
@@ -51,7 +51,7 @@ interface IMessageBridge {
     function getResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
     function getN3Result(uint256 relatedMessageNonce) external view returns (bytes memory);
     function storeMessages(
-        bytes32 evmRoot,
+        bytes32 neoToEvmRoot,
         BridgeLib.Signature[] calldata signatures,
         AMBTypes.MessageData[] calldata messages
     )

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -49,7 +49,7 @@ interface IMessageBridge {
         returns (uint256 nonce);
     function sendResultMessage(uint256 relatedMessageNonce) external payable returns (uint256 nonce);
     function getResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
-    function getN3Result(uint256 relatedMessageNonce) external view returns (bytes memory);
+    function getNeoExecutionResult(uint256 relatedMessageNonce) external view returns (bytes memory);
     function storeMessages(
         bytes32 neoToEvmRoot,
         BridgeLib.Signature[] calldata signatures,

--- a/contracts/tests/TestMessageBridge.sol
+++ b/contracts/tests/TestMessageBridge.sol
@@ -45,8 +45,8 @@ contract TestMessageBridge is MessageBridge {
             paused: true,
             sendingPaused: false,
             executingPaused: false,
-            evmState: StorageTypes.State({nonce: 0, root: 0x0}),
-            n3State: StorageTypes.State({nonce: 0, root: 0x0}),
+            neoToEvmState: StorageTypes.State({nonce: 0, root: 0x0}),
+            evmToNeoState: StorageTypes.State({nonce: 0, root: 0x0}),
             config: MessageConfig({
                 fee: _fee,
                 maxMessageSize: _maxMessageSize,

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -50,7 +50,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         // Store a message to test the remaining getters
         AMBTypes.MessageData[] memory messages = new AMBTypes.MessageData[](1);
         messages[0] = AMBTypes.MessageData({
-            nonce: state.evmState.nonce + 1,
+            nonce: state.neoToEvmState.nonce + 1,
             message: testMessage2,
             encodedMetadata: abi.encode(
                 AMBTypes.MetadataExecutable({
@@ -62,7 +62,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
             )
         });
 
-        bytes32 previousRoot = state.evmState.root;
+        bytes32 previousRoot = state.neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
         vm.prank(relayer);
@@ -112,7 +112,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         });
 
         AMBStorage.MessageBridgeState memory bridgeState = messageBridgeProxy.messageBridgeState();
-        bytes32 previousRoot = bridgeState.evmState.root;
+        bytes32 previousRoot = bridgeState.neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 
@@ -422,7 +422,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message = abi.encode(call);
 
         AMBStorage.MessageBridgeState memory bridgeState = messageBridgeProxy.messageBridgeState();
-        uint256 nonce = bridgeState.evmState.nonce + 1;
+        uint256 nonce = bridgeState.neoToEvmState.nonce + 1;
 
         // Store the message with the nonce
         storeMessage(nonce, message, "");
@@ -460,7 +460,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message = abi.encode(call);
 
         AMBStorage.MessageBridgeState memory bridgeState = messageBridgeProxy.messageBridgeState();
-        uint256 nonce = bridgeState.evmState.nonce + 1;
+        uint256 nonce = bridgeState.neoToEvmState.nonce + 1;
 
         // Store the message with the nonce
         storeMessage(nonce, message, "");
@@ -681,8 +681,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message = abi.encode(call);
 
         // Get current state and nonce
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        uint256 nonce = evmState.nonce + 1;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.messageBridgeState().neoToEvmState;
+        uint256 nonce = neoToEvmState.nonce + 1;
 
         // Store the message with the nonce
         storeMessage(nonce, message, "");
@@ -821,7 +821,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory executableMessage = abi.encodePacked("Test executable message to N3");
 
         // Test that no result exists for the upcoming executable message nonce
-        uint256 upcomingNonce = messageBridgeProxy.messageBridgeState().evmState.nonce + 1;
+        uint256 upcomingNonce = messageBridgeProxy.neoToEvmState().nonce + 1;
         uint256 nonExistentResultNonce = messageBridgeProxy.getN3ResultNonce(upcomingNonce);
         assertEq(nonExistentResultNonce, 0, "No result should exist for upcoming executable message nonce");
         bytes memory nonExistentResult = messageBridgeProxy.getN3Result(upcomingNonce);
@@ -832,8 +832,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertEq(executableNonce, upcomingNonce, "Executable message nonce should match upcoming nonce");
 
         // Verify the message was sent
-        StorageTypes.State memory n3State = messageBridgeProxy.messageBridgeState().n3State;
-        assertEq(n3State.nonce, executableNonce, "N3 state nonce should be updated");
+        StorageTypes.State memory evmToNeoState = messageBridgeProxy.messageBridgeState().evmToNeoState;
+        assertEq(evmToNeoState.nonce, executableNonce, "N3 state nonce should be updated");
 
         // Step 2: Simulate N3 sending back a result message
         bytes memory resultMessageData = abi.encode("Result from N3 for executable message");
@@ -854,8 +854,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         });
 
         // Store the result message from N3
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, resultMessages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 
@@ -907,8 +907,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         });
 
         // Compute the deposit root
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
 
         // Generate valid signatures from validators
@@ -1055,8 +1055,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
             )
         });
 
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot1 = MessageBridgeLib._computeNewTopRoot(previousRoot, messages1);
         BridgeLib.Signature[] memory signatures1 = generateValidSignatures(depositRoot1);
 
@@ -1116,7 +1116,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message = abi.encode(call);
 
         // Get current state and nonce
-        StorageTypes.State memory initialState = messageBridgeProxy.messageBridgeState().evmState;
+        StorageTypes.State memory initialState = messageBridgeProxy.neoToEvmState();
         uint256 nonce = initialState.nonce + 1;
 
         // Store the message with custom metadata
@@ -1156,7 +1156,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message2 = abi.encode(call2);
 
         // Get current state and nonce
-        StorageTypes.State memory initialState = messageBridgeProxy.messageBridgeState().evmState;
+        StorageTypes.State memory initialState = messageBridgeProxy.neoToEvmState();
         uint256 nonce1 = initialState.nonce + 1;
         uint256 nonce2 = nonce1 + 1;
 
@@ -1222,8 +1222,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
             )
         });
 
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 
@@ -1288,10 +1288,10 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message = abi.encodePacked("Test message from EVM to N3");
 
         // Get the initial state
-        StorageTypes.State memory n3State = messageBridgeProxy.messageBridgeState().n3State;
-        uint256 initialNonce = n3State.nonce;
+        StorageTypes.State memory evmToNeoState = messageBridgeProxy.evmToNeoState();
+        uint256 initialNonce = evmToNeoState.nonce;
         uint256 expectedNonce = initialNonce + 1;
-        bytes32 initialRoot = n3State.root;
+        bytes32 initialRoot = evmToNeoState.root;
 
         bytes memory encodedMetadata = abi.encode(
             AMBTypes.MetadataStoreOnly({
@@ -1323,7 +1323,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected");
 
         // Get the updated state
-        StorageTypes.State memory updatedState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
 
         // Verify state changes
         assertEq(updatedState.nonce, expectedNonce, "Nonce should be incremented");
@@ -1374,8 +1374,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         }
 
         // Get the initial state
-        StorageTypes.State memory n3State = messageBridgeProxy.messageBridgeState().n3State;
-        uint256 initialNonce = n3State.nonce;
+        StorageTypes.State memory evmToNeoState = messageBridgeProxy.evmToNeoState();
+        uint256 initialNonce = evmToNeoState.nonce;
         uint256 expectedNonce = initialNonce + 1;
 
         // Send the message (should not revert)
@@ -1383,7 +1383,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected nonce");
 
         // Get the updated state
-        StorageTypes.State memory updatedState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
 
         // Verify nonce increment
         assertEq(updatedState.nonce, expectedNonce, "Nonce should be incremented");
@@ -1454,7 +1454,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.sendMessage{value: messageFee}(emptyMessage);
 
         // Get the updated state
-        StorageTypes.State memory updatedState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
 
         // Verify state changes (should succeed with empty message)
         assertEq(updatedState.nonce, 1, "Nonce should be incremented even with empty message");
@@ -1470,21 +1470,21 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.sendMessage{value: messageFee}(message1);
 
         // Get the state after first message
-        StorageTypes.State memory state1 = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory state1 = messageBridgeProxy.evmToNeoState();
         assertEq(state1.nonce, 1, "Nonce should be 1 after first message");
 
         // Send second message
         messageBridgeProxy.sendMessage{value: messageFee}(message2);
 
         // Get the state after second message
-        StorageTypes.State memory state2 = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory state2 = messageBridgeProxy.evmToNeoState();
         assertEq(state2.nonce, 2, "Nonce should be 2 after second message");
 
         // Send third message
         messageBridgeProxy.sendMessage{value: messageFee}(message3);
 
         // Get the state after third message
-        StorageTypes.State memory state3 = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory state3 = messageBridgeProxy.evmToNeoState();
         assertEq(state3.nonce, 3, "Nonce should be 3 after third message");
 
         // Verify the roots are different
@@ -1517,10 +1517,10 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertTrue(executionResult.success, "Message execution should succeed");
 
         // Get initial state for result message
-        StorageTypes.State memory n3State = messageBridgeProxy.messageBridgeState().n3State;
-        uint256 initialNonce = n3State.nonce;
+        StorageTypes.State memory evmToNeoState = messageBridgeProxy.evmToNeoState();
+        uint256 initialNonce = evmToNeoState.nonce;
         uint256 expectedNonce = initialNonce + 1;
-        bytes32 initialRoot = n3State.root;
+        bytes32 initialRoot = evmToNeoState.root;
 
         // Create expected metadata for result message
         bytes memory expectedMetadata = abi.encode(
@@ -1548,7 +1548,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected");
 
         // Verify state changes
-        StorageTypes.State memory updatedState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
         assertEq(updatedState.nonce, expectedNonce, "Nonce should be incremented");
         assertEq(updatedState.root, expectedRoot, "Root should be updated correctly");
     }
@@ -1715,8 +1715,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertFalse(executionResult.success, "Message execution should fail");
 
         // Get initial state for result message
-        StorageTypes.State memory n3State = messageBridgeProxy.messageBridgeState().n3State;
-        uint256 initialNonce = n3State.nonce;
+        StorageTypes.State memory evmToNeoState = messageBridgeProxy.evmToNeoState();
+        uint256 initialNonce = evmToNeoState.nonce;
         uint256 expectedNonce = initialNonce + 1;
 
         // Send the result message (should work even with failed execution result)
@@ -1724,7 +1724,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected");
 
         // Verify state changes
-        StorageTypes.State memory updatedState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
         assertEq(updatedState.nonce, expectedNonce, "Nonce should be incremented");
     }
 
@@ -1753,20 +1753,20 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.executeMessage{value: 1 ether}(nonce2);
 
         // Get initial state
-        StorageTypes.State memory initialState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory initialState = messageBridgeProxy.evmToNeoState();
 
         // Send first result message
         messageBridgeProxy.sendResultMessage{value: messageFee}(nonce1);
 
         // Verify first result message was sent
-        StorageTypes.State memory stateAfterFirst = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory stateAfterFirst = messageBridgeProxy.evmToNeoState();
         assertEq(stateAfterFirst.nonce, initialState.nonce + 1, "Nonce should be incremented after first result");
 
         // Send second result message
         messageBridgeProxy.sendResultMessage{value: messageFee}(nonce2);
 
         // Verify second result message was sent
-        StorageTypes.State memory stateAfterSecond = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory stateAfterSecond = messageBridgeProxy.evmToNeoState();
         assertEq(stateAfterSecond.nonce, initialState.nonce + 2, "Nonce should be incremented after second result");
 
         // Verify roots are different
@@ -1789,20 +1789,20 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.executeMessage(nonce);
 
         // Get initial state
-        StorageTypes.State memory initialState = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory initialState = messageBridgeProxy.evmToNeoState();
 
         // Send result message first time
         messageBridgeProxy.sendResultMessage{value: messageFee}(nonce);
 
         // Verify first send worked
-        StorageTypes.State memory stateAfterFirst = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory stateAfterFirst = messageBridgeProxy.evmToNeoState();
         assertEq(stateAfterFirst.nonce, initialState.nonce + 1, "Nonce should be incremented after first send");
 
         // Send the same result message again (should work)
         messageBridgeProxy.sendResultMessage{value: messageFee}(nonce);
 
         // Verify second send worked
-        StorageTypes.State memory stateAfterSecond = messageBridgeProxy.messageBridgeState().n3State;
+        StorageTypes.State memory stateAfterSecond = messageBridgeProxy.evmToNeoState();
         assertEq(stateAfterSecond.nonce, initialState.nonce + 2, "Nonce should be incremented after second send");
     }
 
@@ -1837,8 +1837,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         });
 
         // Store the STORE_ONLY message
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -822,9 +822,9 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Test that no result exists for the upcoming executable message nonce
         uint256 upcomingNonce = messageBridgeProxy.neoToEvmState().nonce + 1;
-        uint256 nonExistentResultNonce = messageBridgeProxy.getN3ResultNonce(upcomingNonce);
+        uint256 nonExistentResultNonce = messageBridgeProxy.getNeoExecutionResultNonce(upcomingNonce);
         assertEq(nonExistentResultNonce, 0, "No result should exist for upcoming executable message nonce");
-        bytes memory nonExistentResult = messageBridgeProxy.getN3Result(upcomingNonce);
+        bytes memory nonExistentResult = messageBridgeProxy.getNeoExecutionResult(upcomingNonce);
         assertEq(nonExistentResult.length, 0, "No result data should exist for upcoming executable message nonce");
 
         // Send the executable message and get its nonce
@@ -862,19 +862,19 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.prank(relayer);
         messageBridgeProxy.storeMessages(depositRoot, signatures, resultMessages);
 
-        // Step 3: Test getN3ResultNonce function
-        uint256 resultNonce = messageBridgeProxy.getN3ResultNonce(executableNonce);
+        // Step 3: Test getNeoExecutionResultNonce function
+        uint256 resultNonce = messageBridgeProxy.getNeoExecutionResultNonce(executableNonce);
         assertEq(resultNonce, resultMessages[0].nonce, "Should return the correct result message nonce");
 
-        // Step 4: Test getN3Result function
-        bytes memory retrievedResult = messageBridgeProxy.getN3Result(executableNonce);
+        // Step 4: Test getNeoExecutionResult function
+        bytes memory retrievedResult = messageBridgeProxy.getNeoExecutionResult(executableNonce);
         assertEq(retrievedResult, resultMessageData, "Should return the correct result message data");
 
         // Step 5: Test with non-existent executable message
-        uint256 nonExistentNonce = messageBridgeProxy.getN3ResultNonce(999);
+        uint256 nonExistentNonce = messageBridgeProxy.getNeoExecutionResultNonce(999);
         assertEq(nonExistentNonce, 0, "Should return 0 for non-existent executable message");
 
-        bytes memory emptyResult = messageBridgeProxy.getN3Result(999);
+        bytes memory emptyResult = messageBridgeProxy.getNeoExecutionResult(999);
         assertEq(emptyResult.length, 0, "Should return empty bytes for non-existent executable message");
     }
 

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -29,10 +29,10 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         bytes memory message = _prepareMessage(testContract, arg1, arg2);
 
         // Create metadata and compute hashes
-        (AMBTypes.MetadataExecutable memory metadata, bytes32 newEvmRoot) = _createMetadataAndComputeHashes(message);
+        (AMBTypes.MetadataExecutable memory metadata, bytes32 newNeoToEvmRoot) = _createMetadataAndComputeHashes(message);
 
         // Store the message
-        _storeMessage(metadata, message, newEvmRoot);
+        _storeMessage(metadata, message, newNeoToEvmRoot);
 
         // Execute the message and verify results
         _executeMessageAndVerify(testContract);
@@ -104,7 +104,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
     function _createMetadataAndComputeHashes(bytes memory message)
         private
         view
-        returns (AMBTypes.MetadataExecutable memory metadata, bytes32 newEvmRoot)
+        returns (AMBTypes.MetadataExecutable memory metadata, bytes32 newNeoToEvmRoot)
     {
         // Create metadata for the message
         metadata = AMBTypes.MetadataExecutable({
@@ -136,12 +136,12 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         );
 
         AMBStorage.MessageBridgeState memory bridgeState = messageBridgeProxy.messageBridgeState();
-        bytes32 previousRoot = bridgeState.evmState.root;
+        bytes32 previousRoot = bridgeState.neoToEvmState.root;
         assertEq(previousRoot, hex"0000000000000000000000000000000000000000000000000000000000000000"); // Initial root should be zero
 
-        newEvmRoot = BridgeLib._computeNewRoot(previousRoot, actualMsgHash);
+        newNeoToEvmRoot = BridgeLib._computeNewRoot(previousRoot, actualMsgHash);
         assertEq(
-            newEvmRoot,
+            newNeoToEvmRoot,
             hex"3facb48372d8e7249e3e937f17dcc44f7f1a2978e1652aaa70291789ce7c6b46",
             "New EVM root should match expected value"
         );
@@ -150,7 +150,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
     function _storeMessage(
         AMBTypes.MetadataExecutable memory metadata,
         bytes memory message,
-        bytes32 newEvmRoot
+        bytes32 newNeoToEvmRoot
     )
         private
     {
@@ -158,14 +158,14 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         bytes memory encodedMetadata = abi.encode(metadata);
         messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: encodedMetadata});
 
-        BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
+        BridgeLib.Signature[] memory signatures = generateValidSignatures(newNeoToEvmRoot);
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
+        emit IMessageBridge.NeoToEvmRootUpdate(1, newNeoToEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.Store(1, encodedMetadata);
-        messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
+        messageBridgeProxy.storeMessages(newNeoToEvmRoot, signatures, messages);
     }
 
     function _executeMessageAndVerify(TestContract testContract) private {
@@ -181,7 +181,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
     function test_SyncTest_StoreOnlyMessage() public {
         storeDummyMessageForStoreOnlySyncTest(); // make sure the nonce is at 1 when we start this test
         AMBStorage.MessageBridgeState memory initialBridgeState = messageBridgeProxy.messageBridgeState();
-        bytes32 initialEvmRoot = initialBridgeState.evmState.root;
+        bytes32 initialNeoToEvmRoot = initialBridgeState.neoToEvmState.root;
 
         bytes memory message =
             hex"54686572652773206e6f776865726520492063616e277420676f2e2054686572652773206e6f7768657265204920776f6e27742066696e6420796f752e";
@@ -222,11 +222,11 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         );
 
         // What the initial root should be based on the presetup of the test
-        assertEq(initialEvmRoot, hex"0d3e5e507d5bbe00832f282ca33df9eadabbd5763ec421f3c162cb56d6717abb");
+        assertEq(initialNeoToEvmRoot, hex"0d3e5e507d5bbe00832f282ca33df9eadabbd5763ec421f3c162cb56d6717abb");
 
-        bytes32 newEvmRoot = BridgeLib._computeNewRoot(initialEvmRoot, actualMsgHash);
+        bytes32 newNeoToEvmRoot = BridgeLib._computeNewRoot(initialNeoToEvmRoot, actualMsgHash);
         assertEq(
-            newEvmRoot,
+            newNeoToEvmRoot,
             hex"fb2685cee11e114869c8a7f8b5ccfd08c9c669bb8db88a0eba51940307d1d7b4",
             "New EVM root should match expected value"
         );
@@ -235,14 +235,14 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         bytes memory encodedMetadata = abi.encode(metadata);
         messages[0] = AMBTypes.MessageData({nonce: 2, message: message, encodedMetadata: encodedMetadata});
 
-        BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
+        BridgeLib.Signature[] memory signatures = generateValidSignatures(newNeoToEvmRoot);
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.EvmRootUpdate(2, newEvmRoot);
+        emit IMessageBridge.NeoToEvmRootUpdate(2, newNeoToEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.Store(2, encodedMetadata);
-        messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
+        messageBridgeProxy.storeMessages(newNeoToEvmRoot, signatures, messages);
 
         vm.expectRevert(
             abi.encodeWithSelector(MessageBridgeLib.UnsupportedMessageType.selector, AMBTypes.MessageType.STORE_ONLY)
@@ -253,7 +253,7 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
     function test_SyncTest_ResultMessage() public {
         // storeDummyMessageForStoreOnlySyncTest(); // make sure the nonce is at 1 when we start this test
         AMBStorage.MessageBridgeState memory initialBridgeState = messageBridgeProxy.messageBridgeState();
-        bytes32 initialEvmRoot = initialBridgeState.evmState.root;
+        bytes32 initialNeoToEvmRoot = initialBridgeState.neoToEvmState.root;
 
         bytes memory message = hex"210340420f";
 
@@ -295,11 +295,11 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         );
 
         // What the initial root should be based on the presetup of the test
-        assertEq(initialEvmRoot, hex"0000000000000000000000000000000000000000000000000000000000000000");
+        assertEq(initialNeoToEvmRoot, hex"0000000000000000000000000000000000000000000000000000000000000000");
 
-        bytes32 newEvmRoot = BridgeLib._computeNewRoot(initialEvmRoot, actualMsgHash);
+        bytes32 newNeoToEvmRoot = BridgeLib._computeNewRoot(initialNeoToEvmRoot, actualMsgHash);
         assertEq(
-            newEvmRoot,
+            newNeoToEvmRoot,
             hex"f35faf897372612929949a29991880c3f7e77281410c942270f0017385c37b16",
             "New EVM root should match expected value"
         );
@@ -308,14 +308,14 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         bytes memory encodedMetadata = abi.encode(metadata);
         messages[0] = AMBTypes.MessageData({nonce: 1, message: message, encodedMetadata: encodedMetadata});
 
-        BridgeLib.Signature[] memory signatures = generateValidSignatures(newEvmRoot);
+        BridgeLib.Signature[] memory signatures = generateValidSignatures(newNeoToEvmRoot);
 
         vm.prank(relayer);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
-        emit IMessageBridge.EvmRootUpdate(1, newEvmRoot);
+        emit IMessageBridge.NeoToEvmRootUpdate(1, newNeoToEvmRoot);
         vm.expectEmit(true, true, true, true, address(messageBridgeProxy));
         emit IMessageBridge.Store(1, encodedMetadata);
-        messageBridgeProxy.storeMessages(newEvmRoot, signatures, messages);
+        messageBridgeProxy.storeMessages(newNeoToEvmRoot, signatures, messages);
 
         vm.expectRevert(
             abi.encodeWithSelector(MessageBridgeLib.UnsupportedMessageType.selector, AMBTypes.MessageType.RESULT)

--- a/test/MessageBridgeTestHelper.sol
+++ b/test/MessageBridgeTestHelper.sol
@@ -118,8 +118,8 @@ abstract contract MessageBridgeTestHelper is Test, SigUtils {
             )
         });
 
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.messageBridgeState().neoToEvmState;
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 
@@ -148,8 +148,8 @@ abstract contract MessageBridgeTestHelper is Test, SigUtils {
             )
         });
 
-        StorageTypes.State memory evmState = messageBridgeProxy.messageBridgeState().evmState;
-        bytes32 previousRoot = evmState.root;
+        StorageTypes.State memory neoToEvmState = messageBridgeProxy.neoToEvmState();
+        bytes32 previousRoot = neoToEvmState.root;
         bytes32 depositRoot = MessageBridgeLib._computeNewTopRoot(previousRoot, messages);
         BridgeLib.Signature[] memory signatures = generateValidSignatures(depositRoot);
 


### PR DESCRIPTION
The terms `evmState` and `n3State` are confusing as it is not clear which value corresponds to messages sent from EVM to N3 and which one to messages sent from N3 to EVM.

This pull request tries to resolve this confusion by using clear and precise naming there. As these are related to messages in general, I removed the term message. The following (external) renaming have been done in this pull request:

| Type | Old | New |
|:-|:-|:-|
| Function | `evmState()` | `neoToEvmState()` |
| Function | `n3State()` | `evmToNeoState()` |
| Event | `EvmRootUpdate` | `NeoToEvmRootUpdate` |