### PR TITLE
Rename EVM execution result functions

### DIFF
--- a/contracts/messageBridge/AMBStorage.sol
+++ b/contracts/messageBridge/AMBStorage.sol
@@ -67,7 +67,7 @@ abstract contract AMBStorage {
         return getStorage().evmMessages[nonce];
     }
 
-    function getEvmExecutionResult(uint256 nonce) public view returns (bytes memory) {
+    function getEncodedEvmExecutionResult(uint256 nonce) internal view returns (bytes memory) {
         return getStorage().evmExecutionResults[nonce];
     }
 

--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -187,11 +187,9 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         returns (uint256 nonce)
     {
         // Check if the message exists by checking if it has content
-        if (getEvmMessage(_relatedMessageNonce).rawMessage.length == 0) {
-            revert MessageNotFound(_relatedMessageNonce);
-        }
+        if (getEvmMessage(_relatedMessageNonce).rawMessage.length == 0) revert MessageNotFound(_relatedMessageNonce);
 
-        bytes memory resultMessage = getEvmExecutionResult(_relatedMessageNonce);
+        bytes memory resultMessage = getEncodedEvmExecutionResult(_relatedMessageNonce);
         // Check if a result was stored for this message
         if (resultMessage.length == 0) revert ResultNotFound(_relatedMessageNonce);
 
@@ -211,13 +209,11 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
      * @param relatedMessageNonce The nonce of the related message that was executed.
      * @return result The result of the message execution.
      */
-    function getResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result) {
-        if (getEvmMessage(relatedMessageNonce).rawMessage.length == 0) {
-            revert MessageNotFound(relatedMessageNonce);
-        }
-        bytes memory message = getEvmExecutionResult(relatedMessageNonce);
+    function getEvmExecutionResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result) {
+        if (getEvmMessage(relatedMessageNonce).rawMessage.length == 0) revert MessageNotFound(relatedMessageNonce);
+        bytes memory message = getEncodedEvmExecutionResult(relatedMessageNonce);
         if (message.length == 0) revert ResultNotFound(relatedMessageNonce);
-        return abi.decode(message, (AMBTypes.Result));
+        result = abi.decode(message, (AMBTypes.Result));
     }
 
     /**
@@ -299,9 +295,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         if (MessageBridgeLib._computeNewTopRoot(state.root, _messages) != _neoToEvmRoot) revert InvalidRoot();
 
         // Verify that the provided signatures are valid
-        if (!management().verifyValidatorSignatures(_neoToEvmRoot, _signatures)) {
-            revert InvalidValidatorSignatures();
-        }
+        if (!management().verifyValidatorSignatures(_neoToEvmRoot, _signatures)) revert InvalidValidatorSignatures();
 
         // Update the message bridge deposit state
         getStorage().messageBridgeState.neoToEvmState =
@@ -370,9 +364,8 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
         getStorage().evmExecutableStates[nonce].executed = true;
 
         // Execute the message using the execution manager
-        AMBTypes.Result memory result = execManager.executeMessage{value: msg.value}(
-            nonce, getEvmMessage(nonce).rawMessage, payable(msg.sender)
-        );
+        AMBTypes.Result memory result =
+            execManager.executeMessage{value: msg.value}(nonce, getEvmMessage(nonce).rawMessage, payable(msg.sender));
 
         // Store encode response and emit event
         AMBTypes.MetadataExecutable memory metadata =

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -48,8 +48,8 @@ interface IMessageBridge {
         payable
         returns (uint256 nonce);
     function sendResultMessage(uint256 relatedMessageNonce) external payable returns (uint256 nonce);
-    function getResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
-    function getNeoExecutionResult(uint256 relatedMessageNonce) external view returns (bytes memory);
+    function getEvmExecutionResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
+    function getNeoExecutionResult(uint256 relatedMessageNonce) external view returns (bytes memory result);
     function storeMessages(
         bytes32 neoToEvmRoot,
         BridgeLib.Signature[] calldata signatures,

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -87,8 +87,8 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertTrue(stateAfter.executed, "Message should be executed");
 
         // Test getEvmExecutionResult()
-        bytes memory executionResult = messageBridgeProxy.getEvmExecutionResult(messages[0].nonce);
-        assertGt(executionResult.length, 0, "Execution result should be stored");
+        AMBTypes.Result memory executionResult = messageBridgeProxy.getEvmExecutionResult(messages[0].nonce);
+        assertEq(executionResult.success, true, "Execution result should be stored");
     }
 
     function test_MessageBridgePauseUnpause() public {
@@ -1886,7 +1886,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
 
         // Expect revert with MessageNotFound error
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.MessageNotFound.selector, nonExistentNonce));
-        messageBridgeProxy.getResult(nonExistentNonce);
+        messageBridgeProxy.getEvmExecutionResult(nonExistentNonce);
     }
 
     // test getResult with existing message but no stored result
@@ -1904,7 +1904,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.executeMessage(nonce);
         // Try to get result for the executed message - should revert
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.ResultNotFound.selector, nonce));
-        messageBridgeProxy.getResult(nonce);
+        messageBridgeProxy.getEvmExecutionResult(nonce);
     }
 
     // test getResult with existing message and stored result
@@ -1925,7 +1925,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertTrue(executionResult.success, "Message execution should succeed");
 
         // Get the result for the executed message
-        AMBTypes.Result memory result = messageBridgeProxy.getResult(nonce);
+        AMBTypes.Result memory result = messageBridgeProxy.getEvmExecutionResult(nonce);
 
         // Verify the result matches the execution result
         assertEq(result.success, executionResult.success, "Execution result success should match");
@@ -1946,7 +1946,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         AMBTypes.Result memory executionResult = messageBridgeProxy.executeMessage(nonce);
         assertFalse(executionResult.success, "Message execution should fail");
         // Get the result for the executed message
-        AMBTypes.Result memory result = messageBridgeProxy.getResult(nonce);
+        AMBTypes.Result memory result = messageBridgeProxy.getEvmExecutionResult(nonce);
         // Verify the result matches the execution result
         assertEq(result.success, executionResult.success, "Execution result success should match");
         assertEq(result.returnData, executionResult.returnData, "Execution result return data should match");
@@ -1966,7 +1966,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         AMBTypes.Result memory executionResult = messageBridgeProxy.executeMessage(nonce);
         assertTrue(executionResult.success, "Message execution should succeed");
         // Get the result for the executed message
-        AMBTypes.Result memory result = messageBridgeProxy.getResult(nonce);
+        AMBTypes.Result memory result = messageBridgeProxy.getEvmExecutionResult(nonce);
         // Verify the result matches the execution result
         assertEq(result.success, executionResult.success, "Execution result success should match");
         assertEq(result.returnData, executionResult.returnData, "Execution result return data should match");
@@ -1987,7 +1987,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         assertTrue(executionResult.success, "Message execution should succeed");
         // Expect revert when trying to get result for a message that did not store result
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.ResultNotFound.selector, nonce));
-        messageBridgeProxy.getResult(nonce);
+        messageBridgeProxy.getEvmExecutionResult(nonce);
     }
 
     // test getResult with failWithPanic() method from TestContract
@@ -2005,7 +2005,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         AMBTypes.Result memory executionResult = messageBridgeProxy.executeMessage(nonce);
         assertFalse(executionResult.success, "Message execution should fail with panic");
         // Get the result for the executed message
-        AMBTypes.Result memory result = messageBridgeProxy.getResult(nonce);
+        AMBTypes.Result memory result = messageBridgeProxy.getEvmExecutionResult(nonce);
         // Verify the result matches the execution result
         assertEq(result.success, executionResult.success, "Execution result success should match");
         assertEq(result.returnData, executionResult.returnData, "Execution result return data should match");

--- a/test/MessageBridgeSyncStoring.t.sol
+++ b/test/MessageBridgeSyncStoring.t.sol
@@ -29,7 +29,8 @@ contract MessageBridgeSyncStoring is MessageBridgeTestHelper {
         bytes memory message = _prepareMessage(testContract, arg1, arg2);
 
         // Create metadata and compute hashes
-        (AMBTypes.MetadataExecutable memory metadata, bytes32 newNeoToEvmRoot) = _createMetadataAndComputeHashes(message);
+        (AMBTypes.MetadataExecutable memory metadata, bytes32 newNeoToEvmRoot) =
+            _createMetadataAndComputeHashes(message);
 
         // Store the message
         _storeMessage(metadata, message, newNeoToEvmRoot);


### PR DESCRIPTION
This pull request renames the getter functions for retrieving the results of EVM executions and changes the function that gets the encoded bytes to an internal function.