### PR TITLE
Rename Store-Only Message Send Function

### DIFF
--- a/contracts/messageBridge/MessageBridge.sol
+++ b/contracts/messageBridge/MessageBridge.sol
@@ -205,7 +205,7 @@ contract MessageBridge is IMessageBridge, ReentrancyGuardUpgradeable, UUPSUpgrad
      * @notice Sends a store-only message to the Neo N3 blockchain.
      * @param _message The message to be sent.
      */
-    function sendMessage(bytes calldata _message)
+    function sendStoreOnlyMessage(bytes calldata _message)
         external
         payable
         whenNotPaused

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -39,7 +39,7 @@ interface IMessageBridge {
         external
         view
         returns (AMBStorage.ExecutableState memory executableState);
-    function sendMessage(bytes calldata message) external payable returns (uint256 nonce);
+    function sendStoreOnlyMessage(bytes calldata message) external payable returns (uint256 nonce);
     function sendExecutableMessage(
         bytes calldata _message,
         bool storeResult

--- a/contracts/messageBridge/interfaces/IMessageBridge.sol
+++ b/contracts/messageBridge/interfaces/IMessageBridge.sol
@@ -39,7 +39,6 @@ interface IMessageBridge {
         external
         view
         returns (AMBStorage.ExecutableState memory executableState);
-    function sendStoreOnlyMessage(bytes calldata message) external payable returns (uint256 nonce);
     function sendExecutableMessage(
         bytes calldata _message,
         bool storeResult
@@ -47,6 +46,7 @@ interface IMessageBridge {
         external
         payable
         returns (uint256 nonce);
+    function sendStoreOnlyMessage(bytes calldata message) external payable returns (uint256 nonce);
     function sendResultMessage(uint256 relatedMessageNonce) external payable returns (uint256 nonce);
     function getEvmExecutionResult(uint256 relatedMessageNonce) external view returns (AMBTypes.Result memory result);
     function getNeoExecutionResult(uint256 relatedMessageNonce) external view returns (bytes memory result);

--- a/scripts/utils/messageBridgeUtils.ts
+++ b/scripts/utils/messageBridgeUtils.ts
@@ -97,7 +97,7 @@ export class MessageBridgeUtils {
           { value: fee, ...DEFAULT_TX_OVERRIDES }
         );
       } else if (type === MessageType.STORE_ONLY) {
-        tx = await this.messageBridge.sendMessage(
+        tx = await this.messageBridge.sendStoreOnlyMessage(
           message,
           { value: fee, ...DEFAULT_TX_OVERRIDES }
         );

--- a/test/MessageBridge.t.sol
+++ b/test/MessageBridge.t.sol
@@ -197,7 +197,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         messageBridgeProxy.sendExecutableMessage(testMessage1, false);
 
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.SendingPaused.selector));
-        messageBridgeProxy.sendMessage(testMessage1);
+        messageBridgeProxy.sendStoreOnlyMessage(testMessage1);
     }
 
     function test_pauseExecuting() public {
@@ -1319,7 +1319,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         );
 
         // Send the message with the required fee
-        uint256 newNonce = messageBridgeProxy.sendMessage{value: messageFee}(message);
+        uint256 newNonce = messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(message);
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected");
 
         // Get the updated state
@@ -1341,7 +1341,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.InsufficientFee.selector, messageFee, insufficientFee));
 
         // Send the message with insufficient fee
-        messageBridgeProxy.sendMessage{value: insufficientFee}(message);
+        messageBridgeProxy.sendStoreOnlyMessage{value: insufficientFee}(message);
     }
 
     function test_SendMessage_MessageTooLarge() public {
@@ -1360,7 +1360,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         );
 
         // Send the oversized message
-        messageBridgeProxy.sendMessage{value: messageFee}(largeMessage);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(largeMessage);
     }
 
     function test_SendMessage_ExactMaxMessageSize() public {
@@ -1379,7 +1379,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         uint256 expectedNonce = initialNonce + 1;
 
         // Send the message (should not revert)
-        uint256 newNonce = messageBridgeProxy.sendMessage{value: messageFee}(exactSizeMessage);
+        uint256 newNonce = messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(exactSizeMessage);
         assertEq(newNonce, expectedNonce, "Returned nonce should match expected nonce");
 
         // Get the updated state
@@ -1401,7 +1401,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.MessageBridgePaused.selector));
 
         // Attempt to send a message while the message bridge is paused
-        messageBridgeProxy.sendMessage{value: messageFee}(message);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(message);
     }
 
     function test_SendMessage_ExcessFeeRefund() public {
@@ -1420,7 +1420,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         // Send the message with excess fee
         // Impersonate an EOA to send the message
         vm.prank(owner);
-        messageBridgeProxy.sendMessage{value: excessFee}(message);
+        messageBridgeProxy.sendStoreOnlyMessage{value: excessFee}(message);
 
         // Track balance after sending
         uint256 balanceAfter = address(owner).balance;
@@ -1443,7 +1443,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         // Try to send message from the contract with excess fee
         vm.prank(address(testContract));
         vm.expectRevert(abi.encodeWithSelector(MessageBridge.ExactFeeRequired.selector, messageFee, messageFee * 2));
-        messageBridgeProxy.sendMessage{value: messageFee * 2}(message);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee * 2}(message);
     }
 
     function test_SendMessage_EmptyMessage() public {
@@ -1451,7 +1451,7 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory emptyMessage = new bytes(0);
 
         // Send the empty message
-        messageBridgeProxy.sendMessage{value: messageFee}(emptyMessage);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(emptyMessage);
 
         // Get the updated state
         StorageTypes.State memory updatedState = messageBridgeProxy.evmToNeoState();
@@ -1467,21 +1467,21 @@ contract MessageBridgeTest is MessageBridgeTestHelper {
         bytes memory message3 = abi.encodePacked("Third message");
 
         // Send first message
-        messageBridgeProxy.sendMessage{value: messageFee}(message1);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(message1);
 
         // Get the state after first message
         StorageTypes.State memory state1 = messageBridgeProxy.evmToNeoState();
         assertEq(state1.nonce, 1, "Nonce should be 1 after first message");
 
         // Send second message
-        messageBridgeProxy.sendMessage{value: messageFee}(message2);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(message2);
 
         // Get the state after second message
         StorageTypes.State memory state2 = messageBridgeProxy.evmToNeoState();
         assertEq(state2.nonce, 2, "Nonce should be 2 after second message");
 
         // Send third message
-        messageBridgeProxy.sendMessage{value: messageFee}(message3);
+        messageBridgeProxy.sendStoreOnlyMessage{value: messageFee}(message3);
 
         // Get the state after third message
         StorageTypes.State memory state3 = messageBridgeProxy.evmToNeoState();


### PR DESCRIPTION
This pull request renames `sendMessage` to `sendStoreOnlyMessage`. Using a more precise name here should avoid confusion for users. A user shouldn't be aware of the existence of another function (i.e., `sendExecutableMessage`) to understand that this one will not be executable on the target chain.